### PR TITLE
fix(media): signal screenshare sources to the bridge and recover from connection drops

### DIFF
--- a/src-vue/components/footer/ScreenshareButton.test.ts
+++ b/src-vue/components/footer/ScreenshareButton.test.ts
@@ -31,15 +31,6 @@ describe('ScreenshareButton', () => {
     expect(getJitsiTestContext().jsMeet.createLocalTracks).toHaveBeenCalledWith({
       devices: ['desktop'],
       desktopSharingSources: ['screen', 'window', 'tab'],
-      // Screen capture is capped so a 4K screen at 60fps cannot saturate the
-      // encoder and starve every receiver.
-      desktopSharingFrameRate: { min: 5, max: 15 },
-      constraints: {
-        video: {
-          frameRate: { min: 5, max: 15 },
-          height: { max: 1080 },
-        },
-      },
       firePermissionPromptIsShownEvent: true,
     });
     expect(addSpy).toHaveBeenCalled();

--- a/src-vue/components/footer/ScreenshareButton.test.ts
+++ b/src-vue/components/footer/ScreenshareButton.test.ts
@@ -31,6 +31,15 @@ describe('ScreenshareButton', () => {
     expect(getJitsiTestContext().jsMeet.createLocalTracks).toHaveBeenCalledWith({
       devices: ['desktop'],
       desktopSharingSources: ['screen', 'window', 'tab'],
+      // Screen capture is capped so a 4K screen at 60fps cannot saturate the
+      // encoder and starve every receiver.
+      desktopSharingFrameRate: { min: 5, max: 15 },
+      constraints: {
+        video: {
+          frameRate: { min: 5, max: 15 },
+          height: { max: 1080 },
+        },
+      },
       firePermissionPromptIsShownEvent: true,
     });
     expect(addSpy).toHaveBeenCalled();

--- a/src-vue/components/session/ReconnectingBanner.test.ts
+++ b/src-vue/components/session/ReconnectingBanner.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+import { mountWithApp } from '@/test/mountApp';
+import { useConferenceStore } from '@/stores/conferenceStore';
+import ReconnectingBanner from './ReconnectingBanner.vue';
+
+describe('ReconnectingBanner', () => {
+  beforeEach(() => setActivePinia(createPinia()));
+
+  it('hides while the conference is not interrupted', async () => {
+    const conference = useConferenceStore();
+    conference.isJoined = true;
+    const { wrapper } = await mountWithApp(ReconnectingBanner);
+    expect(wrapper.find('.reconnectingBanner').exists()).toBe(false);
+    wrapper.unmount();
+  });
+
+  it('hides while interrupted but not yet joined', async () => {
+    const conference = useConferenceStore();
+    conference.connectionInterrupted = true;
+    conference.isJoined = false;
+    const { wrapper } = await mountWithApp(ReconnectingBanner);
+    expect(wrapper.find('.reconnectingBanner').exists()).toBe(false);
+    wrapper.unmount();
+  });
+
+  it('shows a live status when the bridge drops mid-session', async () => {
+    const conference = useConferenceStore();
+    conference.isJoined = true;
+    conference.connectionInterrupted = true;
+    const { wrapper } = await mountWithApp(ReconnectingBanner);
+    const banner = wrapper.find('.reconnectingBanner');
+    expect(banner.exists()).toBe(true);
+    expect(banner.attributes('role')).toBe('status');
+    expect(banner.attributes('aria-live')).toBe('polite');
+    expect(banner.text()).toContain('Reconnecting');
+    wrapper.unmount();
+  });
+});

--- a/src-vue/components/session/ReconnectingBanner.vue
+++ b/src-vue/components/session/ReconnectingBanner.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+import { useConferenceStore } from '@/stores/conferenceStore';
+
+const conference = useConferenceStore();
+</script>
+
+<template>
+  <div
+    v-if="conference.connectionInterrupted && conference.isJoined"
+    class="reconnectingBanner"
+    role="status"
+    aria-live="polite"
+  >
+    <span class="spinner" aria-hidden="true" />
+    <span class="label">Reconnecting&hellip;</span>
+  </div>
+</template>
+
+<style scoped>
+.reconnectingBanner {
+  position: fixed;
+  top: max(12px, env(safe-area-inset-top));
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 99999;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 18px;
+  min-height: 44px;
+  border-radius: 999px;
+  background: rgba(20, 20, 20, 0.92);
+  color: #fff;
+  font-size: 15px;
+  font-weight: 600;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.35);
+  pointer-events: none;
+}
+
+.spinner {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-top-color: #fff;
+  animation: reconnectSpin 0.8s linear infinite;
+}
+
+@keyframes reconnectSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spinner {
+    animation-duration: 2.4s;
+  }
+}
+
+@media (max-width: 768px) {
+  .reconnectingBanner {
+    left: 12px;
+    right: 12px;
+    transform: none;
+    justify-content: center;
+    font-size: 16px;
+  }
+}
+</style>

--- a/src-vue/composables/mediaEngineWiring.test.ts
+++ b/src-vue/composables/mediaEngineWiring.test.ts
@@ -810,6 +810,26 @@ describe('wireStoreSync', () => {
     jitsi.conference._fire(ev.conference.CONFERENCE_JOINED);
     expect(syncSpy).not.toHaveBeenCalled();
   });
+
+  it('flags a dropped bridge and re-asks for sources on restore', () => {
+    const engine = getMediaEngineInstance();
+    const conference = useConferenceStore();
+    const local = useLocalStore();
+    const refresh = vi.spyOn(local, 'calculateUsersOnScreen');
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      cb(0);
+      return 0;
+    });
+    wireStoreSync(engine);
+    const emit = (engine as unknown as { emit: (event: string) => void }).emit.bind(engine);
+    emit('connectionInterrupted');
+    expect(conference.connectionInterrupted).toBe(true);
+    emit('connectionRestored');
+    expect(conference.connectionInterrupted).toBe(false);
+    expect(refresh).toHaveBeenCalled();
+    refresh.mockRestore();
+    vi.unstubAllGlobals();
+  });
 });
 
 

--- a/src-vue/composables/mediaEngineWiring.ts
+++ b/src-vue/composables/mediaEngineWiring.ts
@@ -84,6 +84,17 @@ export function wireStoreSync(engine: MediaService): void {
       isJoining: false,
     });
   });
+  engine.on('connectionInterrupted', () => {
+    mediaDebug('wiring', 'connectionInterrupted', {});
+    conferenceStore.setConnectionInterrupted(true);
+  });
+  engine.on('connectionRestored', () => {
+    mediaDebug('wiring', 'connectionRestored', {});
+    conferenceStore.setConnectionInterrupted(false);
+    // The bridge forgets receiver constraints across the drop, so remote tiles
+    // stay black on reconnect unless we ask for the sources again.
+    scheduleReceiverRefresh();
+  });
   engine.on('userJoined', (id, user) => {
     conferenceStore.addUser(id, user);
     const props = sanitizeParticipantProperties(

--- a/src-vue/config/jitsiOptions.test.ts
+++ b/src-vue/config/jitsiOptions.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
-  conferenceNameDefault,
-  conferenceOptions,
-  desktopSharingConstraints,
-  jitsiInitOptions,
-} from './jitsiOptions';
+import { conferenceNameDefault, conferenceOptions, jitsiInitOptions } from './jitsiOptions';
 
 describe('jitsiOptions', () => {
   it('exports loungemesh defaults', () => {
@@ -23,8 +18,10 @@ describe('jitsiOptions', () => {
     expect(conferenceOptions.enableLayerSuspension).toBe(true);
   });
 
-  it('caps desktop capture so a shared 4K screen cannot saturate the encoder', () => {
-    expect(desktopSharingConstraints.frameRate).toEqual({ min: 5, max: 15 });
-    expect(desktopSharingConstraints.maxHeight).toBe(1080);
+  it('prefers VP9 over AV1 so long-haul links do not freeze tiles', () => {
+    expect(conferenceOptions.videoQuality).toEqual({
+      codecPreferenceOrder: ['VP9', 'VP8', 'H264', 'AV1'],
+      mobileCodecPreferenceOrder: ['VP8', 'VP9', 'H264', 'AV1'],
+    });
   });
 });

--- a/src-vue/config/jitsiOptions.test.ts
+++ b/src-vue/config/jitsiOptions.test.ts
@@ -1,14 +1,30 @@
 import { describe, expect, it } from 'vitest';
-import { conferenceNameDefault, conferenceOptions, jitsiInitOptions } from './jitsiOptions';
+import {
+  conferenceNameDefault,
+  conferenceOptions,
+  desktopSharingConstraints,
+  jitsiInitOptions,
+} from './jitsiOptions';
 
 describe('jitsiOptions', () => {
   it('exports loungemesh defaults', () => {
     expect(conferenceNameDefault).toBe('loungemesh');
-    expect(conferenceOptions.channelLastN).toBe(16);
+    expect(conferenceOptions.channelLastN).toBe(9);
     expect(conferenceOptions.openBridgeChannel).toBe('datachannel');
     expect(conferenceOptions.p2p).toEqual({ enabled: false });
-    expect(conferenceOptions.disableSimulcast).toBe(true);
     expect(jitsiInitOptions.disableAudioLevels).toBe(true);
     expect(jitsiInitOptions.enableWindowOnErrorHandler).toBe(false);
+  });
+
+  it('keeps simulcast on so the bridge degrades per receiver, not per sender', () => {
+    // With a single encoding JVB pushes the lowest receiver constraint back onto
+    // the sender, so one small tile drags the stream down for everyone.
+    expect(conferenceOptions.disableSimulcast).toBe(false);
+    expect(conferenceOptions.enableLayerSuspension).toBe(true);
+  });
+
+  it('caps desktop capture so a shared 4K screen cannot saturate the encoder', () => {
+    expect(desktopSharingConstraints.frameRate).toEqual({ min: 5, max: 15 });
+    expect(desktopSharingConstraints.maxHeight).toBe(1080);
   });
 });

--- a/src-vue/config/jitsiOptions.ts
+++ b/src-vue/config/jitsiOptions.ts
@@ -35,22 +35,13 @@ export const conferenceOptions = {
   /** Let the bridge stop sending higher layers for tiles nobody is looking at. */
   enableLayerSuspension: true,
   /**
-   * AV1 and VP9 cost far less bandwidth than VP8 at the same resolution, which
-   * matters most on constrained links where the bridge would otherwise suspend
-   * streams outright. H264 stays last as the universal fallback.
+   * VP9 (KSVC) and VP8 recover cleanly under loss and packet reordering on
+   * long-haul links. AV1 is cheaper per pixel but its dependency descriptor
+   * freezes tiles on those paths, so it stays last-resort. H264 is the
+   * universal fallback.
    */
   videoQuality: {
-    codecPreferenceOrder: ['AV1', 'VP9', 'VP8', 'H264'],
+    codecPreferenceOrder: ['VP9', 'VP8', 'H264', 'AV1'],
     mobileCodecPreferenceOrder: ['VP8', 'VP9', 'H264', 'AV1'],
   },
-};
-
-/**
- * Desktop capture constraints. A shared screen is mostly static text, so frame
- * rate buys very little while costing a lot of encode CPU and bitrate — the
- * classic Jitsi deployment caps it the same way.
- */
-export const desktopSharingConstraints = {
-  frameRate: { min: 5, max: 15 },
-  maxHeight: 1080,
 };

--- a/src-vue/config/jitsiOptions.ts
+++ b/src-vue/config/jitsiOptions.ts
@@ -19,10 +19,38 @@ export const conferenceOptions = {
   /** Always use JVB — P2P breaks replaceTrack / remote media in LoungeMesh. */
   p2p: { enabled: false },
   /**
-   * Single video encoding per sender. Simpler and reliable for LoungeMesh tiles;
-   * avoids simulcast setParameters edge cases across Chrome/Firefox.
+   * Simulcast gives the bridge several encodings to choose between. Without it
+   * there is only one, so JVB has to push the *lowest* constraint any receiver
+   * asked for back onto the sender — one participant on a small tile then
+   * degrades the stream for everyone, and a screen share drops to tile
+   * resolution. Keep it on so the bridge can drop layers per receiver instead.
    */
-  disableSimulcast: true,
-  channelLastN: 16,
-  enableLayerSuspension: false,
+  disableSimulcast: false,
+  /**
+   * Cap on simultaneously forwarded video sources. 9 matches the classic Jitsi
+   * deployment and keeps decode cost sane on a ~12 person team; screen shares
+   * are budgeted on top of this in buildReceiverConstraints.
+   */
+  channelLastN: 9,
+  /** Let the bridge stop sending higher layers for tiles nobody is looking at. */
+  enableLayerSuspension: true,
+  /**
+   * AV1 and VP9 cost far less bandwidth than VP8 at the same resolution, which
+   * matters most on constrained links where the bridge would otherwise suspend
+   * streams outright. H264 stays last as the universal fallback.
+   */
+  videoQuality: {
+    codecPreferenceOrder: ['AV1', 'VP9', 'VP8', 'H264'],
+    mobileCodecPreferenceOrder: ['VP8', 'VP9', 'H264', 'AV1'],
+  },
+};
+
+/**
+ * Desktop capture constraints. A shared screen is mostly static text, so frame
+ * rate buys very little while costing a lot of encode CPU and bitrate — the
+ * classic Jitsi deployment caps it the same way.
+ */
+export const desktopSharingConstraints = {
+  frameRate: { min: 5, max: 15 },
+  maxHeight: 1080,
 };

--- a/src-vue/pages/SessionPage.vue
+++ b/src-vue/pages/SessionPage.vue
@@ -26,6 +26,7 @@ const SessionFeaturePanels = defineAsyncComponent(
   () => import('@/components/session/SessionFeaturePanels.vue'),
 );
 const LobbyOverlay = defineAsyncComponent(() => import('@/components/session/LobbyOverlay.vue'));
+import ReconnectingBanner from '@/components/session/ReconnectingBanner.vue';
 const WhiteboardOverlay = defineAsyncComponent(
   () => import('@/components/session/WhiteboardOverlay.vue'),
 );
@@ -183,6 +184,7 @@ onBeforeUnmount(() => {
   <JitsiConnection />
   <LocalStoreLogic />
   <LobbyOverlay />
+  <ReconnectingBanner />
   <PanWrapper :event-identifier="identifier">
     <Room :identifier="identifier">
       <RemoteUsers />

--- a/src-vue/services/JitsiAdapter.test.ts
+++ b/src-vue/services/JitsiAdapter.test.ts
@@ -358,6 +358,30 @@ describe('JitsiAdapter', () => {
     expect(adapter.isJoined()).toBe(true);
   });
 
+  it('skips restore listener when the library does not expose it', async () => {
+    await adapter.connect();
+    mock.connection._fire(mock.jsMeet.events.connection.CONNECTION_ESTABLISHED);
+    delete mock.jsMeet.events.conference.CONNECTION_RESTORED;
+    await adapter.joinRoom('room', 'A', {});
+    mock.conference._fire(mock.jsMeet.events.conference.CONFERENCE_JOINED);
+    expect(adapter.isJoined()).toBe(true);
+  });
+
+  it('emits reconnect events when the bridge drops and recovers', async () => {
+    await adapter.connect();
+    mock.connection._fire(mock.jsMeet.events.connection.CONNECTION_ESTABLISHED);
+    await adapter.joinRoom('room', 'A', {});
+    const interrupted = vi.fn();
+    const restored = vi.fn();
+    adapter.on('connectionInterrupted', interrupted);
+    adapter.on('connectionRestored', restored);
+    const ev = mock.jsMeet.events.conference;
+    mock.conference._fire(ev.CONNECTION_INTERRUPTED);
+    mock.conference._fire(ev.CONNECTION_RESTORED);
+    expect(interrupted).toHaveBeenCalledTimes(1);
+    expect(restored).toHaveBeenCalledTimes(1);
+  });
+
   it('manages local tracks and conference commands', async () => {
     await adapter.connect();
     mock.connection._fire(mock.jsMeet.events.connection.CONNECTION_ESTABLISHED);

--- a/src-vue/services/JitsiAdapter.ts
+++ b/src-vue/services/JitsiAdapter.ts
@@ -1,5 +1,5 @@
 import { getConnectionOptions } from '@/config/connectionOptions';
-import { desktopSharingConstraints, jitsiInitOptions } from '@/config/jitsiOptions';
+import { jitsiInitOptions } from '@/config/jitsiOptions';
 import { conferenceErrorDetail } from '@/services/conferenceErrorDetail';
 import { secureConferenceName } from '@/utils/secureConferenceName';
 import type { JitsiConference, JitsiMeetJS, JitsiTrack, ReceiverConstraints } from '@/types/jitsi';
@@ -349,20 +349,12 @@ export class JitsiAdapter implements MediaService {
     this.init();
     const options = { firePermissionPromptIsShownEvent: true };
     if (devices.includes('desktop')) {
+      // Do not set desktopSharingFrameRate. max > 5 tells Chrome to prefer fps
+      // over resolution and turns on screenshare simulcast, so JVB forwards a
+      // low layer (jitsi-meet#15611 / #14884). Unset = sharp share at ~5 fps.
       return this.jsMeet!.createLocalTracks({
         devices: ['desktop'],
         desktopSharingSources: ['screen', 'window', 'tab'],
-        // Uncapped, the browser captures a 4K screen at up to 60fps and encodes
-        // it in a single pass, which stutters on modest hardware and starves
-        // every receiver. Screen content is mostly static, so trading frame rate
-        // for resolution is what keeps shared text readable.
-        desktopSharingFrameRate: desktopSharingConstraints.frameRate,
-        constraints: {
-          video: {
-            frameRate: desktopSharingConstraints.frameRate,
-            height: { max: desktopSharingConstraints.maxHeight },
-          },
-        },
         ...options,
       } as any);
     }

--- a/src-vue/services/JitsiAdapter.ts
+++ b/src-vue/services/JitsiAdapter.ts
@@ -1,5 +1,5 @@
 import { getConnectionOptions } from '@/config/connectionOptions';
-import { jitsiInitOptions } from '@/config/jitsiOptions';
+import { desktopSharingConstraints, jitsiInitOptions } from '@/config/jitsiOptions';
 import { conferenceErrorDetail } from '@/services/conferenceErrorDetail';
 import { secureConferenceName } from '@/utils/secureConferenceName';
 import type { JitsiConference, JitsiMeetJS, JitsiTrack, ReceiverConstraints } from '@/types/jitsi';
@@ -237,6 +237,21 @@ export class JitsiAdapter implements MediaService {
       this.conference = undefined;
       this.joined = false;
     });
+    // The bridge connection can drop without the conference failing. Without
+    // these the SPA keeps rendering dead tracks until the user reloads, which is
+    // the main reason Office feels less reliable than classic Jitsi on flaky links.
+    if (ev.CONNECTION_INTERRUPTED) {
+      conference.on(ev.CONNECTION_INTERRUPTED, () => {
+        mediaDebug('JitsiAdapter', 'CONNECTION_INTERRUPTED', {});
+        this.emit('connectionInterrupted');
+      });
+    }
+    if (ev.CONNECTION_RESTORED) {
+      conference.on(ev.CONNECTION_RESTORED, () => {
+        mediaDebug('JitsiAdapter', 'CONNECTION_RESTORED', {});
+        this.emit('connectionRestored');
+      });
+    }
     conference.on(ev.TRACK_ADDED, (track: unknown) => {
       const t = track as JitsiTrack;
       mediaDebugTrack('JitsiAdapter', 'TRACK_ADDED', t);
@@ -337,6 +352,17 @@ export class JitsiAdapter implements MediaService {
       return this.jsMeet!.createLocalTracks({
         devices: ['desktop'],
         desktopSharingSources: ['screen', 'window', 'tab'],
+        // Uncapped, the browser captures a 4K screen at up to 60fps and encodes
+        // it in a single pass, which stutters on modest hardware and starves
+        // every receiver. Screen content is mostly static, so trading frame rate
+        // for resolution is what keeps shared text readable.
+        desktopSharingFrameRate: desktopSharingConstraints.frameRate,
+        constraints: {
+          video: {
+            frameRate: desktopSharingConstraints.frameRate,
+            height: { max: desktopSharingConstraints.maxHeight },
+          },
+        },
         ...options,
       } as any);
     }

--- a/src-vue/services/MediaService.ts
+++ b/src-vue/services/MediaService.ts
@@ -20,6 +20,8 @@ export type MediaServiceEvent =
   | 'connectionFailed'
   | 'conferenceJoined'
   | 'conferenceError'
+  | 'connectionInterrupted'
+  | 'connectionRestored'
   | 'userJoined'
   | 'userLeft'
   | 'trackAdded'
@@ -38,6 +40,10 @@ export type MediaServiceEventMap = {
   connectionFailed: [detail: string];
   conferenceJoined: [];
   conferenceError: [detail: string];
+  /** Bridge connection dropped; media is stalled but the conference is alive. */
+  connectionInterrupted: [];
+  /** Bridge connection came back; receiver constraints must be re-sent. */
+  connectionRestored: [];
   userJoined: [id: string, user: unknown];
   userLeft: [id: string];
   trackAdded: [track: JitsiTrack];

--- a/src-vue/stores/conferenceStore.test.ts
+++ b/src-vue/stores/conferenceStore.test.ts
@@ -251,11 +251,21 @@ describe('conferenceStore', () => {
     const store = useConferenceStore();
     store.addUser('u5');
     store.isJoined = true;
+    store.connectionInterrupted = true;
     store.messages = [{ id: 'u5', text: 'hi', nr: 1 }];
     store.leaveConference();
     expect(store.isJoined).toBe(false);
     expect(store.users).toEqual({});
     expect(store.messages).toEqual([]);
+    expect(store.connectionInterrupted).toBe(false);
+  });
+
+  it('setConnectionInterrupted toggles the reconnect flag', () => {
+    const store = useConferenceStore();
+    store.setConnectionInterrupted(true);
+    expect(store.connectionInterrupted).toBe(true);
+    store.setConnectionInterrupted(false);
+    expect(store.connectionInterrupted).toBe(false);
   });
 
   it('handles screenshareAudio track actions', () => {

--- a/src-vue/stores/conferenceStore.ts
+++ b/src-vue/stores/conferenceStore.ts
@@ -49,6 +49,11 @@ export type ConferenceState = {
   displayName: string;
   error?: string;
   messages: ChatMessage[];
+  /**
+   * Bridge connection dropped while the conference is still alive. Media is
+   * stalled but recoverable, so this is a transient banner rather than an error.
+   */
+  connectionInterrupted: boolean;
 };
 
 /** Conference UI state — media events sync via useMediaEngine. */
@@ -63,8 +68,12 @@ export const useConferenceStore = defineStore('conference', {
     displayName: 'Friendly Sphere',
     error: undefined,
     messages: [],
+    connectionInterrupted: false,
   }),
   actions: {
+    setConnectionInterrupted(interrupted: boolean) {
+      this.connectionInterrupted = interrupted;
+    },
     setConferenceName(name: string) {
       this.conferenceName = name;
     },

--- a/src-vue/stores/conferenceStore.ts
+++ b/src-vue/stores/conferenceStore.ts
@@ -234,6 +234,7 @@ export const useConferenceStore = defineStore('conference', {
       this.clearJoinState();
       this.messages = [];
       this.error = undefined;
+      this.connectionInterrupted = false;
       useSessionFeaturesStore().resetForLeave();
     },
   },

--- a/src-vue/stores/localStore.test.ts
+++ b/src-vue/stores/localStore.test.ts
@@ -152,6 +152,31 @@ describe('localStore', () => {
     constraintsSpy.mockRestore();
   });
 
+  it('calculateUsersOnScreen ignores missing remote user records', () => {
+    const conference = useConferenceStore();
+    conference.commitUsers({ ghost: undefined as never });
+    const store = useLocalStore();
+    store.id = 'me';
+    store.calculateUsersOnScreen();
+    expect(store.visibleUsers).toEqual([]);
+  });
+
+  it('calculateUsersOnScreen requests remote screen shares by source name', () => {
+    const conference = useConferenceStore();
+    conference.addUser('sharer');
+    const desktop = { getType: () => 'video', videoType: 'desktop', getSourceName: () => 'sharer-v1' } as never;
+    conference.patchUser('sharer', { screenshare: desktop });
+    const engine = getMediaEngineInstance();
+    const constraintsSpy = vi.spyOn(engine, 'setReceiverConstraints');
+    const store = useLocalStore();
+    store.id = 'me';
+    store.calculateUsersOnScreen();
+    const sent = constraintsSpy.mock.calls[0][0];
+    expect(sent.selectedSources).toEqual(expect.arrayContaining(['sharer-v0', 'sharer-v1']));
+    expect(sent.onStageSources).toEqual(expect.arrayContaining(['sharer-v1']));
+    constraintsSpy.mockRestore();
+  });
+
   it('toggleMute releases the mic on mute and re-acquires it on unmute', async () => {
     const existing = {
       getType: () => 'audio',

--- a/src-vue/stores/localStore.ts
+++ b/src-vue/stores/localStore.ts
@@ -216,11 +216,18 @@ export const useLocalStore = defineStore('local', {
       });
 
       if (conferenceOptions.openBridgeChannel) {
+        // Screen shares are a second video source per endpoint, so the bridge
+        // needs them named explicitly or it falls back to tile resolution.
+        const screenshareTracks: Record<string, JitsiTrack | undefined> = {};
+        for (const [uid, user] of Object.entries(users)) {
+          if (user?.screenshare) screenshareTracks[uid] = user.screenshare;
+        }
         const constraints = buildReceiverConstraints({
           localId: this.id,
           remoteUserIds: Object.keys(users),
           visibleUserIds: this.visibleUsers,
           stageIds: this.usersOnStage,
+          screenshareTracks,
         });
         if (constraints) {
           mediaDebug('localStore', 'setReceiverConstraints', {

--- a/src-vue/test/jitsiMock.ts
+++ b/src-vue/test/jitsiMock.ts
@@ -92,6 +92,8 @@ export function installJitsiMock(): JitsiMockHandles {
       MESSAGE_RECEIVED: 'conference.messageReceived',
       PARTICIPANT_PROPERTY_CHANGED: 'conference.participantPropertyChanged',
       DISPLAY_NAME_CHANGED: 'conference.displayNameChanged',
+      CONNECTION_INTERRUPTED: 'conference.connectionInterrupted',
+      CONNECTION_RESTORED: 'conference.connectionRestored',
     },
   };
 

--- a/src-vue/types/jitsi.ts
+++ b/src-vue/types/jitsi.ts
@@ -15,6 +15,11 @@ export interface JitsiTrack {
   id: string;
   getId(): string;
   getTrack(): MediaStreamTrack;
+  /**
+   * Multi-stream source name (`<endpointId>-v0` for camera, `-v1` for a screen
+   * share). Required to address a specific source in receiver constraints.
+   */
+  getSourceName?(): string;
 }
 
 export interface ReceiverConstraints {
@@ -81,6 +86,9 @@ export interface JitsiMeetJSEvents {
     CONFERENCE_JOINED: string;
     CONFERENCE_FAILED: string;
     CONFERENCE_ERROR: string;
+    /** Bridge channel lost / regained without the conference itself failing. */
+    CONNECTION_INTERRUPTED?: string;
+    CONNECTION_RESTORED?: string;
     TRACK_ADDED: string;
     TRACK_MUTE_CHANGED: string;
     TRACK_REMOVED: string;

--- a/src-vue/utils/receiverConstraints.test.ts
+++ b/src-vue/utils/receiverConstraints.test.ts
@@ -1,6 +1,15 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { conferenceOptions } from '@/config/jitsiOptions';
+import type { JitsiTrack } from '@/types/jitsi';
 import { buildReceiverConstraints } from './receiverConstraints';
+
+/** Minimal stand-in for a remote desktop track. */
+function desktopTrack(sourceName?: string): JitsiTrack {
+  return {
+    videoType: 'desktop',
+    ...(sourceName ? { getSourceName: () => sourceName } : {}),
+  } as unknown as JitsiTrack;
+}
 
 describe('buildReceiverConstraints', () => {
   it('returns null when there are no remote participants', () => {
@@ -57,6 +66,71 @@ describe('buildReceiverConstraints', () => {
       stageIds: [],
     });
     expect(constraints?.lastN).toBe(1);
+  });
+
+  describe('screen shares', () => {
+    it('requests the share source at full resolution, not tile resolution', () => {
+      const constraints = buildReceiverConstraints({
+        localId: 'me',
+        remoteUserIds: ['a', 'b'],
+        visibleUserIds: ['a', 'b'],
+        stageIds: [],
+        screenshareTracks: { a: desktopTrack() },
+      });
+      // Without this the share falls through to defaultConstraints (360p) and
+      // shared text is unreadable.
+      expect(constraints?.constraints['a-v1']).toEqual({ maxHeight: 1080 });
+      expect(constraints?.selectedSources).toContain('a-v1');
+    });
+
+    it('treats an active share as on-stage', () => {
+      const constraints = buildReceiverConstraints({
+        localId: 'me',
+        remoteUserIds: ['a'],
+        visibleUserIds: ['a'],
+        stageIds: [],
+        screenshareTracks: { a: desktopTrack() },
+      });
+      expect(constraints?.onStageSources).toContain('a-v1');
+    });
+
+    it('prefers the source name reported by the track over the -v1 convention', () => {
+      const constraints = buildReceiverConstraints({
+        localId: 'me',
+        remoteUserIds: ['a'],
+        visibleUserIds: ['a'],
+        stageIds: [],
+        screenshareTracks: { a: desktopTrack('a-v3') },
+      });
+      expect(constraints?.selectedSources).toContain('a-v3');
+      expect(constraints?.constraints['a-v3']).toEqual({ maxHeight: 1080 });
+    });
+
+    it('budgets shares on top of channelLastN so a share cannot evict a camera', () => {
+      const ids = Array.from({ length: 9 }, (_, i) => `u${i}`);
+      const constraints = buildReceiverConstraints({
+        localId: 'me',
+        remoteUserIds: ids,
+        visibleUserIds: ids,
+        stageIds: [],
+        screenshareTracks: { u0: desktopTrack() },
+      });
+      // 9 cameras (the channelLastN cap) plus 1 share = 10 forwarded sources.
+      // Capping at 9 is what made a tile or the share go black when sharing.
+      expect(constraints?.lastN).toBe(10);
+    });
+
+    it('ignores shares from endpoints that are not remote participants', () => {
+      const constraints = buildReceiverConstraints({
+        localId: 'me',
+        remoteUserIds: ['a'],
+        visibleUserIds: ['a'],
+        stageIds: [],
+        screenshareTracks: { me: desktopTrack(), ghost: desktopTrack() },
+      });
+      expect(constraints?.selectedSources).not.toContain('me-v1');
+      expect(constraints?.selectedSources).not.toContain('ghost-v1');
+    });
   });
 
   describe('channelLastN fallback', () => {

--- a/src-vue/utils/receiverConstraints.ts
+++ b/src-vue/utils/receiverConstraints.ts
@@ -1,12 +1,43 @@
-import type { ReceiverConstraints } from '@/types/jitsi';
+import type { JitsiTrack, ReceiverConstraints } from '@/types/jitsi';
 import { conferenceOptions } from '@/config/jitsiOptions';
 
-/** Build Jitsi receiver constraints so remote camera tracks are actually forwarded. */
+/** Remote camera tile. */
+const TILE_MAX_HEIGHT = 360;
+/** Remote camera promoted to the stage. */
+const STAGE_MAX_HEIGHT = 720;
+/**
+ * Remote screen share. Shares carry text, so they need far more detail than a
+ * face does — at 360 a shared IDE or slide deck is unreadable.
+ */
+const SCREENSHARE_MAX_HEIGHT = 1080;
+
+/**
+ * Jitsi runs in multi-stream mode (`sourceNameSignaling` + `receiveMultipleVideoStreams`),
+ * so one endpoint can publish several video sources. lib-jitsi-meet names them
+ * `<endpointId>-v<n>`: the camera is `-v0` and a screen share is `-v1`.
+ *
+ * Prefer the name the track reports over the convention — the numbering is an
+ * implementation detail of lib-jitsi-meet and only holds while an endpoint
+ * publishes its sources in the expected order.
+ */
+function sourceNameFor(endpointId: string, index: number, track?: JitsiTrack): string {
+  return track?.getSourceName?.() || `${endpointId}-v${index}`;
+}
+
+/**
+ * Build Jitsi receiver constraints so remote video is actually forwarded.
+ *
+ * The bridge only sends a source if the receiver asks for it by name, so any
+ * source missing from `constraints` falls back to `defaultConstraints` and any
+ * source beyond `lastN` is suspended outright.
+ */
 export function buildReceiverConstraints(opts: {
   localId: string;
   remoteUserIds: string[];
   visibleUserIds: string[];
   stageIds: string[];
+  /** Remote desktop tracks by endpoint id, so shares can be requested by real source name. */
+  screenshareTracks?: Record<string, JitsiTrack | undefined>;
 }): ReceiverConstraints | null {
   const remoteUserIds = opts.remoteUserIds.filter((id) => id && id !== opts.localId);
   if (!remoteUserIds.length) return null;
@@ -20,29 +51,47 @@ export function buildReceiverConstraints(opts: {
   } else {
     selectedEndpoints = [...new Set([...selectedEndpoints, ...remoteUserIds])];
   }
-  const selectedSources = selectedEndpoints.map((id) => `${id}-v0`);
+
+  const cameraSources = selectedEndpoints.map((id) => sourceNameFor(id, 0));
+
+  // A screen share is requested for every remote endpoint that has one, whether
+  // or not their avatar happens to be in the viewport: people look at the share,
+  // not at the person sharing.
+  const shares = opts.screenshareTracks ?? {};
+  const screenshareSources = remoteUserIds
+    .filter((id) => shares[id])
+    .map((id) => sourceNameFor(id, 1, shares[id]));
+
+  const selectedSources = [...new Set([...cameraSources, ...screenshareSources])];
 
   const channelLastN =
     typeof conferenceOptions.channelLastN === 'number' && conferenceOptions.channelLastN > 0
       ? conferenceOptions.channelLastN
       : 20;
-  const lastN = Math.max(1, Math.min(selectedEndpoints.length, channelLastN));
 
-  const onStageSources = stage.map((id) => `${id}-v0`);
+  // lastN counts sources, not endpoints. Budget cameras against channelLastN and
+  // add shares on top, otherwise starting a share pushes a camera over the limit
+  // and the bridge silently drops one of them.
+  const cameraBudget = Math.min(cameraSources.length, channelLastN);
+  const lastN = Math.max(1, cameraBudget + screenshareSources.length);
+
+  const onStageSources = [
+    ...new Set([...stage.map((id) => sourceNameFor(id, 0)), ...screenshareSources]),
+  ];
 
   // Per-source constraints are what actually make modern JVB forward a source.
   // Relying on `lastN` + `selectedSources` alone leaves the `constraints` map
   // empty, which is why remote tiles can stay black or only update after a
-  // refresh. Request every selected source explicitly (on-stage at a higher
-  // resolution) so the bridge forwards them as soon as they exist.
-  const TILE_MAX_HEIGHT = 360;
-  const STAGE_MAX_HEIGHT = 720;
+  // refresh. Request every selected source explicitly.
   const constraints: Record<string, { maxHeight: number }> = {};
-  for (const source of selectedSources) {
+  for (const source of cameraSources) {
     constraints[source] = { maxHeight: TILE_MAX_HEIGHT };
   }
-  for (const source of onStageSources) {
+  for (const source of stage.map((id) => sourceNameFor(id, 0))) {
     constraints[source] = { maxHeight: STAGE_MAX_HEIGHT };
+  }
+  for (const source of screenshareSources) {
+    constraints[source] = { maxHeight: SCREENSHARE_MAX_HEIGHT };
   }
 
   // NOTE: no colibriClass here — lib-jitsi-meet wraps this object as a


### PR DESCRIPTION
## Summary

Remote screen shares are effectively broken in multi-stream mode: they arrive blurry, and starting one can black out an unrelated camera tile.

`buildReceiverConstraints` synthesises every source name as `${endpointId}-v0`. In multi-stream mode (`sourceNameSignaling` + `receiveMultipleVideoStreams`, which is the default on recent `jitsi/web`) a screen share is a **second** video source, `-v1`. So the bridge never receives a constraint for it:

- the share falls through to `defaultConstraints` (360p), which makes shared text unreadable; and
- `lastN` is computed from the number of **endpoints**, while JVB counts **sources**. With N remotes and a share there are N+1 sources against a budget of N, so the bridge drops one — either the share or somebody's camera.

```ts
const selectedSources = selectedEndpoints.map((id) => `${id}-v0`);
const lastN = Math.max(1, Math.min(selectedEndpoints.length, channelLastN));
```

This is made worse by `disableSimulcast: true`. With a single encoding the bridge has no layer to drop per receiver, so it pushes the lowest receiver constraint back onto the **sender** — one participant on a small tile degrades the stream for everyone, and a share drops to tile resolution globally.

## Changes

**Screen share signalling** (`utils/receiverConstraints.ts`)
- Derive source names from `track.getSourceName()` instead of synthesising them, falling back to the `-v0`/`-v1` convention only when unavailable.
- Request every remote share at 1080p and treat it as on-stage; a share is what people are actually looking at.
- Budget shares on top of `channelLastN` so a share can never evict a camera.
- `localStore` passes the remote desktop tracks it already tracks, so real source names are available.

**Conference options** (`config/jitsiOptions.ts`)
- Re-enable simulcast, so the bridge degrades per receiver rather than per sender.
- `channelLastN` 16 → 9 and layer suspension on, to cut client decode cost.
- Codec order **VP9, VP8, H264, AV1** (mobile: VP8 first, AV1 last). AV1-first froze tiles on long-haul links (loss/reordering); this matches current Jitsi Meet practice. Do **not** cap `desktopSharingFrameRate` at 5–15: in current Jitsi `max > 5` tells Chrome to prefer fps over resolution and turns on screenshare simulcast, so JVB forwards a low layer ([jitsi-meet#15611](https://github.com/jitsi/jitsi-meet/issues/15611), [#14884](https://github.com/jitsi/jitsi-meet/issues/14884)). Unset = sharp share at ~5 fps.

**Connection recovery** (`services/JitsiAdapter.ts`, `mediaEngineWiring.ts`, `ReconnectingBanner.vue`)
- There were no `CONNECTION_INTERRUPTED` / `CONNECTION_RESTORED` listeners at all. The bridge connection can drop without the conference failing, and the SPA kept rendering dead tracks until the user reloaded.
- Show a reconnecting banner and re-send receiver constraints on restore, since the bridge forgets them across the drop.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npx vitest run` — 100% coverage
- [x] `npm run build` succeeds
- [x] Unit tests cover share source naming, on-stage promotion, the `lastN` budget, `getSourceName` preference, ignoring shares from non-participants, ReconnectingBanner, and reconnect wiring
- [x] Deployed to a production install (12-person team, docker-jitsi-meet `stable-10888`)

Verify manually in `chrome://webrtc-internals`: with two participants and a share, the inbound screenshare track should resolve above 360p and no camera tile should drop while sharing.

Made with [Cursor](https://cursor.com)
