### PR TITLE
feat(ui): local grid of people currently in hearing range

### DIFF
--- a/docs-site/.vitepress/config.ts
+++ b/docs-site/.vitepress/config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
           { text: 'Session error codes', link: '/guide/error-codes' },
           { text: 'Publishing docs', link: '/guide/publishing-docs' },
           { text: 'Implementation status', link: '/guide/status' },
+          { text: 'In-room controls', link: '/guide/in-room-controls' },
           { text: 'Contributing', link: '/guide/contributing' },
         ],
       },

--- a/docs-site/guide/in-room-controls.md
+++ b/docs-site/guide/in-room-controls.md
@@ -1,0 +1,23 @@
+# In-room controls
+
+LoungeMesh keeps you in the spatial room. These controls work **after you have joined**, without leaving the session.
+
+## Devices
+
+Open **Device settings** (gear) in the footer on the enter screen or in the room.
+
+- Pick a camera, microphone, or speaker
+- The last choice is remembered in this browser
+- Speakers use `setSinkId` where the browser supports it
+
+On phones the list opens as a bottom sheet.
+
+## Speak to all
+
+**Speak to all** (megaphone) makes everyone in the current room hear you at equal volume, including people outside your usual audio bubble. Your tile grows so others can see who is addressing the room.
+
+This is not Stage. Use **Stage** when you want a presentation overlay; use megaphone when you just need to be heard across the map.
+
+## Sphere grid
+
+**Grid view** (next to zoom) shows tiles for people currently in your hearing range. It is local-only: other participants stay on the map. Toggle it off to return to the spatial view.

--- a/docs-site/guide/status.md
+++ b/docs-site/guide/status.md
@@ -22,6 +22,9 @@ This page is a living snapshot of what is built, what is in progress, and what i
 | Chat panel | ✅ Complete |
 | Stage / screenshare support | ✅ Complete |
 | Mute/unmute controls | ✅ Complete |
+| In-session camera / mic / speaker picker | ✅ Complete |
+| Megaphone (speak to everyone in the room) | ✅ Complete |
+| Sphere grid view of people in hearing range | ✅ Complete |
 | Session prefix (`secureConferenceName`) | ✅ Complete |
 | `sessionConnectionWatch` lifecycle | ✅ Complete |
 | 100% Vitest coverage (lines/statements/functions/branches) | ✅ 268 tests |

--- a/src-vue/components/footer/DeviceSettingsButton.test.ts
+++ b/src-vue/components/footer/DeviceSettingsButton.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { flushPromises } from '@vue/test-utils';
+import { setActivePinia, createPinia } from 'pinia';
+import { mountWithApp } from '@/test/mountApp';
+import DeviceSettingsButton from './DeviceSettingsButton.vue';
+
+describe('DeviceSettingsButton', () => {
+  beforeEach(() => setActivePinia(createPinia()));
+
+  it('opens and closes the device panel', async () => {
+    const { wrapper } = await mountWithApp(DeviceSettingsButton);
+    expect(wrapper.find('[aria-label="Device settings"]').exists()).toBe(true);
+    await wrapper.find('[aria-label="Device settings"]').trigger('click');
+    await flushPromises();
+    expect(wrapper.findComponent({ name: 'DeviceSettingsPanel' }).exists()).toBe(true);
+    await wrapper.find('[aria-label="Device settings"]').trigger('click');
+    expect(wrapper.findComponent({ name: 'DeviceSettingsPanel' }).exists()).toBe(false);
+    await wrapper.find('[aria-label="Device settings"]').trigger('click');
+    wrapper.findComponent({ name: 'DeviceSettingsPanel' }).vm.$emit('close');
+    await wrapper.vm.$nextTick();
+    expect(wrapper.findComponent({ name: 'DeviceSettingsPanel' }).exists()).toBe(false);
+    wrapper.unmount();
+  });
+});

--- a/src-vue/components/footer/DeviceSettingsButton.vue
+++ b/src-vue/components/footer/DeviceSettingsButton.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import IconButton from '@/components/ui/IconButton.vue';
+import AppIcon from '@/components/ui/AppIcon.vue';
+import DeviceSettingsPanel from './DeviceSettingsPanel.vue';
+
+const open = ref(false);
+
+function toggle() {
+  open.value = !open.value;
+}
+</script>
+
+<template>
+  <div class="deviceWrap">
+    <IconButton
+      label="Device settings"
+      :active="open"
+      sound="panel"
+      @click="toggle"
+    >
+      <template #icon><AppIcon name="settings" /></template>
+    </IconButton>
+    <DeviceSettingsPanel v-if="open" @close="open = false" />
+  </div>
+</template>
+
+<style scoped>
+.deviceWrap {
+  position: relative;
+  display: inline-flex;
+  overflow: visible;
+}
+</style>

--- a/src-vue/components/footer/DeviceSettingsPanel.test.ts
+++ b/src-vue/components/footer/DeviceSettingsPanel.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { flushPromises } from '@vue/test-utils';
+import { setActivePinia, createPinia } from 'pinia';
+import { mountWithApp } from '@/test/mountApp';
+import { useLocalStore } from '@/stores/localStore';
+import {
+  MEDIA_DEVICE_PREFS_KEY,
+  saveMediaDevicePrefs,
+} from '@/utils/mediaDevicePrefs';
+import DeviceSettingsPanel from './DeviceSettingsPanel.vue';
+
+vi.mock('@/utils/deviceSettings', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('@/utils/deviceSettings')>();
+  return {
+    ...orig,
+    supportsAudioOutput: () => mockSupportsOutput(),
+  };
+});
+
+let mockSupportsOutput = () => true;
+
+function fakeDevice(kind: MediaDeviceKind, deviceId: string, label = ''): MediaDeviceInfo {
+  return { kind, deviceId, label, groupId: '', toJSON: () => ({}) } as MediaDeviceInfo;
+}
+
+describe('DeviceSettingsPanel', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    localStorage.removeItem(MEDIA_DEVICE_PREFS_KEY);
+    mockSupportsOutput = () => true;
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: {
+        enumerateDevices: vi.fn().mockResolvedValue([
+          fakeDevice('audioinput', 'm1', 'Mic One'),
+          fakeDevice('videoinput', 'c1', 'Cam One'),
+          fakeDevice('audiooutput', 's1', 'Speakers'),
+        ]),
+      },
+    });
+  });
+
+  it('lists devices and switches camera, mic, and speaker', async () => {
+    saveMediaDevicePrefs({ videoinput: 'c1', audioinput: 'm1', audiooutput: 's1' });
+    const local = useLocalStore();
+    const cam = vi.spyOn(local, 'switchVideoInput').mockResolvedValue(undefined);
+    const mic = vi.spyOn(local, 'switchAudioInput').mockResolvedValue(undefined);
+    const out = vi.spyOn(local, 'switchAudioOutput').mockResolvedValue(undefined);
+    const { wrapper } = await mountWithApp(DeviceSettingsPanel);
+    await flushPromises();
+    expect(wrapper.find('[aria-label="Device settings"]').exists()).toBe(true);
+    const rows = wrapper.findAll('button.deviceRow');
+    expect(rows).toHaveLength(3);
+    await rows[0].trigger('click');
+    await rows[1].trigger('click');
+    await rows[2].trigger('click');
+    expect(cam).toHaveBeenCalledWith('c1');
+    expect(mic).toHaveBeenCalledWith('m1');
+    expect(out).toHaveBeenCalledWith('s1');
+    wrapper.unmount();
+  });
+
+  it('shows empty-state copy when no devices are available', async () => {
+    (navigator.mediaDevices.enumerateDevices as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    const { wrapper } = await mountWithApp(DeviceSettingsPanel);
+    await flushPromises();
+    expect(wrapper.text()).toContain('No cameras found');
+    expect(wrapper.text()).toContain('No microphones found');
+    expect(wrapper.text()).toContain('No speakers found');
+    wrapper.unmount();
+  });
+
+  it('hides speakers when setSinkId is unsupported', async () => {
+    mockSupportsOutput = () => false;
+    const { wrapper } = await mountWithApp(DeviceSettingsPanel);
+    await flushPromises();
+    expect(wrapper.text()).not.toContain('Speaker');
+    wrapper.unmount();
+  });
+
+  it('closes from backdrop, close button, and Escape', async () => {
+    const { wrapper } = await mountWithApp(DeviceSettingsPanel);
+    await flushPromises();
+    await wrapper.find('.deviceBackdrop').trigger('click');
+    expect(wrapper.emitted('close')?.length).toBe(1);
+    await wrapper.find('.closeRow').trigger('click');
+    expect(wrapper.emitted('close')?.length).toBe(2);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    expect(wrapper.emitted('close')?.length).toBe(3);
+    wrapper.unmount();
+  });
+});

--- a/src-vue/components/footer/DeviceSettingsPanel.vue
+++ b/src-vue/components/footer/DeviceSettingsPanel.vue
@@ -1,0 +1,192 @@
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref } from 'vue';
+import { useLocalStore } from '@/stores/localStore';
+import { deviceLabel, listMediaDevices, type ListedMediaDevices } from '@/utils/listMediaDevices';
+import { loadMediaDevicePrefs } from '@/utils/mediaDevicePrefs';
+import {
+  deviceGroupLabel,
+  fallbackDeviceLabel,
+  supportsAudioOutput,
+  type DeviceKind,
+} from '@/utils/deviceSettings';
+
+const emit = defineEmits<{ close: [] }>();
+const local = useLocalStore();
+const listed = ref<ListedMediaDevices>({ audioInputs: [], videoInputs: [], audioOutputs: [] });
+const prefs = ref(loadMediaDevicePrefs());
+const showSpeakers = computed(() => supportsAudioOutput());
+
+async function refresh() {
+  listed.value = await listMediaDevices();
+  prefs.value = loadMediaDevicePrefs();
+}
+
+function onKey(e: KeyboardEvent) {
+  if (e.key === 'Escape') emit('close');
+}
+
+onMounted(() => {
+  void refresh();
+  document.addEventListener('keydown', onKey);
+});
+
+onUnmounted(() => {
+  document.removeEventListener('keydown', onKey);
+});
+
+function optionLabel(kind: DeviceKind, device: MediaDeviceInfo, index: number): string {
+  return deviceLabel(device, fallbackDeviceLabel(kind, index));
+}
+
+async function pick(kind: DeviceKind, deviceId: string) {
+  if (kind === 'audioinput') await local.switchAudioInput(deviceId);
+  else if (kind === 'videoinput') await local.switchVideoInput(deviceId);
+  else await local.switchAudioOutput(deviceId);
+  prefs.value = loadMediaDevicePrefs();
+}
+
+function selected(kind: DeviceKind): string | undefined {
+  return prefs.value[kind];
+}
+</script>
+
+<template>
+  <div class="deviceBackdrop" @click="emit('close')" />
+  <div
+    class="deviceSheet"
+    role="dialog"
+    aria-label="Device settings"
+    @click.stop
+  >
+    <h2 class="sheetTitle">Devices</h2>
+    <section class="group">
+      <h3>{{ deviceGroupLabel('videoinput') }}</h3>
+      <p v-if="!listed.videoInputs.length" class="empty">No cameras found</p>
+      <button
+        v-for="(device, index) in listed.videoInputs"
+        :key="device.deviceId"
+        type="button"
+        class="deviceRow"
+        :class="{ selected: selected('videoinput') === device.deviceId }"
+        :aria-pressed="selected('videoinput') === device.deviceId"
+        @click="pick('videoinput', device.deviceId)"
+      >
+        {{ optionLabel('videoinput', device, index) }}
+      </button>
+    </section>
+    <section class="group">
+      <h3>{{ deviceGroupLabel('audioinput') }}</h3>
+      <p v-if="!listed.audioInputs.length" class="empty">No microphones found</p>
+      <button
+        v-for="(device, index) in listed.audioInputs"
+        :key="device.deviceId"
+        type="button"
+        class="deviceRow"
+        :class="{ selected: selected('audioinput') === device.deviceId }"
+        :aria-pressed="selected('audioinput') === device.deviceId"
+        @click="pick('audioinput', device.deviceId)"
+      >
+        {{ optionLabel('audioinput', device, index) }}
+      </button>
+    </section>
+    <section v-if="showSpeakers" class="group">
+      <h3>{{ deviceGroupLabel('audiooutput') }}</h3>
+      <p v-if="!listed.audioOutputs.length" class="empty">No speakers found</p>
+      <button
+        v-for="(device, index) in listed.audioOutputs"
+        :key="device.deviceId"
+        type="button"
+        class="deviceRow"
+        :class="{ selected: selected('audiooutput') === device.deviceId }"
+        :aria-pressed="selected('audiooutput') === device.deviceId"
+        @click="pick('audiooutput', device.deviceId)"
+      >
+        {{ optionLabel('audiooutput', device, index) }}
+      </button>
+    </section>
+    <button type="button" class="closeRow" @click="emit('close')">Close</button>
+  </div>
+</template>
+
+<style scoped>
+.deviceBackdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.35);
+  z-index: 99999;
+}
+.deviceSheet {
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 8px);
+  transform: translateX(-50%);
+  z-index: 100000;
+  width: min(360px, calc(100vw - 24px));
+  max-height: min(520px, 60vh);
+  overflow-x: hidden;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  padding: 14px;
+  border-radius: var(--radius-sm);
+  background: #fff;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18);
+  box-sizing: border-box;
+}
+.sheetTitle {
+  margin: 0 0 10px;
+  font-size: var(--fs-h2);
+  font-weight: var(--fw-medium);
+  text-align: center;
+}
+.group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 12px;
+}
+.group h3 {
+  margin: 0;
+  font-size: var(--fs-small);
+  font-weight: var(--fw-medium);
+  color: var(--color-mono30);
+}
+.empty {
+  margin: 0;
+  font-size: 16px;
+  color: var(--color-mono30);
+}
+.deviceRow,
+.closeRow {
+  min-height: 44px;
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid var(--line-dark, #d0d5dd);
+  border-radius: var(--radius-sm);
+  background: #fff;
+  font-size: 16px;
+  font-family: var(--font-body);
+  text-align: left;
+  cursor: pointer;
+}
+.deviceRow.selected {
+  border-color: var(--color-blue100);
+  background: var(--color-blue10, #e4eaff);
+}
+.closeRow {
+  text-align: center;
+  font-weight: var(--fw-medium);
+}
+
+@media (max-width: 768px) {
+  .deviceSheet {
+    position: fixed !important;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    transform: none;
+    width: 100%;
+    max-height: 70vh;
+    border-radius: 14px 14px 0 0;
+  }
+}
+</style>

--- a/src-vue/components/layout/PanWrapper.vue
+++ b/src-vue/components/layout/PanWrapper.vue
@@ -5,7 +5,7 @@ import { applyZoomStep, clampedPanZoom, wheelScaleDelta } from '@/constants/panZ
 import ZoomControls from '@/components/layout/ZoomControls.vue';
 import ViewportBackground from '@/components/layout/ViewportBackground.vue';
 
-const props = defineProps<{ eventIdentifier?: string }>();
+const props = withDefaults(defineProps<{ eventIdentifier?: string; showGrid?: boolean }>(), { showGrid: true });
 
 const localStore = useLocalStore();
 const isPanning = ref(false);
@@ -74,7 +74,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <ZoomControls class="zoomCorner" />
+  <ZoomControls class="zoomCorner" :show-grid="props.showGrid" />
   <div
     ref="wrapperRef"
     class="panRoot"

--- a/src-vue/components/layout/PanWrapper.vue
+++ b/src-vue/components/layout/PanWrapper.vue
@@ -5,7 +5,7 @@ import { applyZoomStep, clampedPanZoom, wheelScaleDelta } from '@/constants/panZ
 import ZoomControls from '@/components/layout/ZoomControls.vue';
 import ViewportBackground from '@/components/layout/ViewportBackground.vue';
 
-const props = withDefaults(defineProps<{ eventIdentifier?: string; showGrid?: boolean }>(), { showGrid: true });
+const props = defineProps<{ eventIdentifier?: string }>();
 
 const localStore = useLocalStore();
 const isPanning = ref(false);
@@ -74,7 +74,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <ZoomControls class="zoomCorner" :show-grid="props.showGrid" />
+  <ZoomControls />
   <div
     ref="wrapperRef"
     class="panRoot"
@@ -126,12 +126,5 @@ onMounted(() => {
 }
 .panScale:active {
   cursor: grabbing;
-}
-.zoomCorner {
-  position: fixed;
-  left: 14px;
-  bottom: 96px;
-  z-index: 6000;
-  pointer-events: auto;
 }
 </style>

--- a/src-vue/components/layout/ZoomControls.test.ts
+++ b/src-vue/components/layout/ZoomControls.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
 import { mountWithApp } from '@/test/mountApp';
 import { useLocalStore } from '@/stores/localStore';
-import { useSessionFeaturesStore } from '@/stores/sessionFeaturesStore';
 import ZoomControls from './ZoomControls.vue';
 
 describe('ZoomControls', () => {
@@ -13,6 +12,7 @@ describe('ZoomControls', () => {
     const start = local.scale;
     const { wrapper } = await mountWithApp(ZoomControls);
     const buttons = wrapper.findAll('button.ibtn');
+    expect(buttons).toHaveLength(2);
     await buttons[0].trigger('click');
     expect(local.scale).toBeGreaterThan(start);
     const mid = local.scale;
@@ -26,25 +26,6 @@ describe('ZoomControls', () => {
     const strip = wrapper.find('.zoomCtl');
     await strip.trigger('pointerdown');
     await strip.trigger('click');
-    wrapper.unmount();
-  });
-
-  it('toggles grid view', async () => {
-    const features = useSessionFeaturesStore();
-    const { wrapper } = await mountWithApp(ZoomControls);
-    const buttons = wrapper.findAll('button.ibtn');
-    expect(buttons[2].attributes('aria-label')).toBe('Grid view');
-    await buttons[2].trigger('click');
-    expect(features.gridView).toBe(true);
-    await buttons[2].trigger('click');
-    expect(features.gridView).toBe(false);
-    wrapper.unmount();
-  });
-
-  it('hides the grid toggle when showGrid is false', async () => {
-    const { wrapper } = await mountWithApp(ZoomControls, { props: { showGrid: false } });
-    const labels = wrapper.findAll('button.ibtn').map((b) => b.attributes('aria-label'));
-    expect(labels).toEqual(['Zoom in', 'Zoom out']);
     wrapper.unmount();
   });
 });

--- a/src-vue/components/layout/ZoomControls.test.ts
+++ b/src-vue/components/layout/ZoomControls.test.ts
@@ -40,4 +40,11 @@ describe('ZoomControls', () => {
     expect(features.gridView).toBe(false);
     wrapper.unmount();
   });
+
+  it('hides the grid toggle when showGrid is false', async () => {
+    const { wrapper } = await mountWithApp(ZoomControls, { props: { showGrid: false } });
+    const labels = wrapper.findAll('button.ibtn').map((b) => b.attributes('aria-label'));
+    expect(labels).toEqual(['Zoom in', 'Zoom out']);
+    wrapper.unmount();
+  });
 });

--- a/src-vue/components/layout/ZoomControls.test.ts
+++ b/src-vue/components/layout/ZoomControls.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
 import { mountWithApp } from '@/test/mountApp';
 import { useLocalStore } from '@/stores/localStore';
+import { useSessionFeaturesStore } from '@/stores/sessionFeaturesStore';
 import ZoomControls from './ZoomControls.vue';
 
 describe('ZoomControls', () => {
@@ -25,6 +26,18 @@ describe('ZoomControls', () => {
     const strip = wrapper.find('.zoomCtl');
     await strip.trigger('pointerdown');
     await strip.trigger('click');
+    wrapper.unmount();
+  });
+
+  it('toggles grid view', async () => {
+    const features = useSessionFeaturesStore();
+    const { wrapper } = await mountWithApp(ZoomControls);
+    const buttons = wrapper.findAll('button.ibtn');
+    expect(buttons[2].attributes('aria-label')).toBe('Grid view');
+    await buttons[2].trigger('click');
+    expect(features.gridView).toBe(true);
+    await buttons[2].trigger('click');
+    expect(features.gridView).toBe(false);
     wrapper.unmount();
   });
 });

--- a/src-vue/components/layout/ZoomControls.vue
+++ b/src-vue/components/layout/ZoomControls.vue
@@ -1,14 +1,11 @@
 <script setup lang="ts">
 import { useLocalStore } from '@/stores/localStore';
-import { useSessionFeaturesStore } from '@/stores/sessionFeaturesStore';
 import { applyZoomStep, clampedPanZoom } from '@/constants/panZoom';
 import { viewportChrome, visibleViewport } from '@/constants/pan';
 import IconButton from '@/components/ui/IconButton.vue';
 import AppIcon from '@/components/ui/AppIcon.vue';
 
-const props = withDefaults(defineProps<{ showGrid?: boolean }>(), { showGrid: true });
 const local = useLocalStore();
-const features = useSessionFeaturesStore();
 const ZOOM_STEP = 0.12;
 
 function anchor() {
@@ -36,29 +33,40 @@ function zoomOut() {
 
 <template>
   <div class="zoomCtl" @pointerdown.stop @click.stop>
-    <IconButton label="Zoom in" ghost @click.stop="zoomIn">
+    <IconButton label="Zoom in" @click.stop="zoomIn">
       <template #icon><AppIcon name="plus" /></template>
     </IconButton>
-    <IconButton label="Zoom out" ghost @click.stop="zoomOut">
+    <IconButton label="Zoom out" @click.stop="zoomOut">
       <template #icon><AppIcon name="minus" /></template>
-    </IconButton>
-    <IconButton
-      v-if="props.showGrid"
-      :label="features.gridView ? 'Exit grid view' : 'Grid view'"
-      ghost
-      :active="features.gridView"
-      @click.stop="features.gridView = !features.gridView"
-    >
-      <template #icon><AppIcon name="layout-grid" /></template>
     </IconButton>
   </div>
 </template>
 
 <style scoped>
 .zoomCtl {
+  position: fixed;
+  left: 14px;
+  bottom: 96px;
+  z-index: 6000;
+  pointer-events: auto;
   display: inline-flex;
   flex-direction: column;
   gap: 4px;
   align-items: center;
+  padding: 6px;
+  border-radius: 28px;
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: 0 2px 10px rgba(15, 23, 42, 0.18);
+}
+
+@media (max-width: 768px) {
+  .zoomCtl {
+    left: 10px;
+    bottom: 148px;
+  }
+  .zoomCtl :deep(.ibtn) {
+    min-height: 44px;
+    min-width: 44px;
+  }
 }
 </style>

--- a/src-vue/components/layout/ZoomControls.vue
+++ b/src-vue/components/layout/ZoomControls.vue
@@ -6,6 +6,7 @@ import { viewportChrome, visibleViewport } from '@/constants/pan';
 import IconButton from '@/components/ui/IconButton.vue';
 import AppIcon from '@/components/ui/AppIcon.vue';
 
+const props = withDefaults(defineProps<{ showGrid?: boolean }>(), { showGrid: true });
 const local = useLocalStore();
 const features = useSessionFeaturesStore();
 const ZOOM_STEP = 0.12;
@@ -42,6 +43,7 @@ function zoomOut() {
       <template #icon><AppIcon name="minus" /></template>
     </IconButton>
     <IconButton
+      v-if="props.showGrid"
       :label="features.gridView ? 'Exit grid view' : 'Grid view'"
       ghost
       :active="features.gridView"

--- a/src-vue/components/layout/ZoomControls.vue
+++ b/src-vue/components/layout/ZoomControls.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import { useLocalStore } from '@/stores/localStore';
+import { useSessionFeaturesStore } from '@/stores/sessionFeaturesStore';
 import { applyZoomStep, clampedPanZoom } from '@/constants/panZoom';
 import { viewportChrome, visibleViewport } from '@/constants/pan';
 import IconButton from '@/components/ui/IconButton.vue';
 import AppIcon from '@/components/ui/AppIcon.vue';
 
 const local = useLocalStore();
+const features = useSessionFeaturesStore();
 const ZOOM_STEP = 0.12;
 
 function anchor() {
@@ -38,6 +40,14 @@ function zoomOut() {
     </IconButton>
     <IconButton label="Zoom out" ghost @click.stop="zoomOut">
       <template #icon><AppIcon name="minus" /></template>
+    </IconButton>
+    <IconButton
+      :label="features.gridView ? 'Exit grid view' : 'Grid view'"
+      ghost
+      :active="features.gridView"
+      @click.stop="features.gridView = !features.gridView"
+    >
+      <template #icon><AppIcon name="layout-grid" /></template>
     </IconButton>
   </div>
 </template>

--- a/src-vue/components/room/GridTileVideo.test.ts
+++ b/src-vue/components/room/GridTileVideo.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { flushPromises } from '@vue/test-utils';
+import { setActivePinia, createPinia } from 'pinia';
+import { mountWithApp } from '@/test/mountApp';
+import { makeTrack } from '@/test/makeTrack';
+import GridTileVideo from './GridTileVideo.vue';
+
+describe('GridTileVideo', () => {
+  beforeEach(() => setActivePinia(createPinia()));
+
+  it('attaches, replaces, and detaches a track', async () => {
+    const first = makeTrack('video');
+    const second = makeTrack('video');
+    const { wrapper } = await mountWithApp(GridTileVideo, {
+      props: { track: first, muted: true },
+    });
+    await flushPromises();
+    expect(first.attach).toHaveBeenCalled();
+    await wrapper.setProps({ track: second });
+    await flushPromises();
+    expect(second.attach).toHaveBeenCalled();
+    await wrapper.setProps({ track: undefined });
+    await flushPromises();
+    wrapper.unmount();
+  });
+
+  it('renders unmuted by default', async () => {
+    const { wrapper } = await mountWithApp(GridTileVideo, { props: { track: makeTrack('video') } });
+    expect((wrapper.find('video').element as HTMLVideoElement).muted).toBe(false);
+    wrapper.unmount();
+  });
+});

--- a/src-vue/components/room/GridTileVideo.vue
+++ b/src-vue/components/room/GridTileVideo.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { nextTick, onBeforeUnmount, ref, watch } from 'vue';
+import type { JitsiTrack } from '@/types/jitsi';
+import { attachGridTrack, detachGridTrack } from '@/utils/attachGridTrack';
+
+const props = defineProps<{
+  track?: JitsiTrack;
+  muted?: boolean;
+}>();
+
+const el = ref<HTMLVideoElement | null>(null);
+
+watch(
+  () => props.track,
+  async (track) => {
+    await nextTick();
+    attachGridTrack(el.value, track);
+  },
+  { immediate: true },
+);
+
+onBeforeUnmount(() => {
+  detachGridTrack(el.value, props.track);
+});
+</script>
+
+<template>
+  <video ref="el" class="vid" autoplay playsinline :muted="!!muted" />
+</template>
+
+<style scoped>
+.vid {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  background: #0f172a;
+}
+</style>

--- a/src-vue/components/room/LocalUser.test.ts
+++ b/src-vue/components/room/LocalUser.test.ts
@@ -171,6 +171,17 @@ describe('LocalUser', () => {
     wrapper.unmount();
   });
 
+  it('shows megaphone styling when speaking to all', async () => {
+    const local = useLocalStore();
+    const features = useSessionFeaturesStore();
+    local.setMyID('local-1');
+    features.megaphone = true;
+    const { wrapper } = await mountWithApp(LocalUser);
+    expect(wrapper.find('.videoContainer.megaphone').exists()).toBe(true);
+    expect(wrapper.find('.megaphoneBadge').exists()).toBe(true);
+    wrapper.unmount();
+  });
+
   it('detaches the previous camera track when the track changes', async () => {
     const local = useLocalStore();
     local.setMyID('local-1');

--- a/src-vue/components/room/LocalUser.vue
+++ b/src-vue/components/room/LocalUser.vue
@@ -51,6 +51,7 @@ const showCameraVideo = computed(() => hasVideo.value && !local.cameraOff);
 const showAvatar = computed(() => !showCameraVideo.value || isStageOccupant.value);
 const reaction = computed(() => (local.id ? features.userReactions[local.id]?.emoji : undefined));
 const handUp = computed(() => features.handRaised);
+const megaphoneOn = computed(() => features.megaphone);
 const isStageOccupant = computed(() => features.isLocalStageOccupant);
 
 function releaseVideoPreview() {
@@ -184,11 +185,13 @@ defineExpose({ attach, videoEl });
           avatarTile: showAvatar,
           speaking: local.speaking && !local.mute && showAvatar,
           onStageOccupant: isStageOccupant,
+          megaphone: megaphoneOn,
         }"
       >
         <UserBackdrop v-if="showAvatar" :onStage="isStageOccupant" :displayName="conference.displayName" :avatarUrl="auth.user?.avatarUrl" />
         <MuteIndicator v-if="local.mute" clickable @click="local.toggleMute()" />
         <div v-if="handUp" class="handBadge" title="Hand raised">✋</div>
+        <div v-if="megaphoneOn" class="megaphoneBadge" title="Speaking to all">📣</div>
         <span v-if="reaction" class="floatReact">{{ reaction }}</span>
         <video
           v-if="!showAvatar"

--- a/src-vue/components/room/RemoteUser.test.ts
+++ b/src-vue/components/room/RemoteUser.test.ts
@@ -139,4 +139,24 @@ describe('RemoteUser', () => {
 
     wrapper.unmount();
   });
+
+  it('enlarges a megaphone speaker and keeps them audible outside the sphere', async () => {
+    const conference = useConferenceStore();
+    const local = useLocalStore();
+    const features = useSessionFeaturesStore();
+    local.pos = { x: 0, y: 0 };
+    conference.addUser('loud', { _displayName: 'Loud' } as never);
+    const u = conference.users.loud;
+    u.pos = { x: 1000, y: 0 };
+    u.video = makeTrack('video');
+    u.speaking = true;
+    u.mute = false;
+    u.properties = { megaphone: true };
+    features.stageOccupantId = 'someone-else';
+    const { wrapper } = await mountWithApp(RemoteUser, { props: { id: 'loud' } });
+    expect(wrapper.find('.videoContainer.megaphone').exists()).toBe(true);
+    expect(wrapper.find('.megaphoneBadge').exists()).toBe(true);
+    expect(wrapper.find('video.remoteVideo').exists()).toBe(true);
+    wrapper.unmount();
+  });
 });

--- a/src-vue/components/room/RemoteUser.vue
+++ b/src-vue/components/room/RemoteUser.vue
@@ -11,6 +11,7 @@ import NameTag from './overlays/NameTag.vue';
 import UserBackdrop from './overlays/UserBackdrop.vue';
 import MuteIndicator from './overlays/MuteIndicator.vue';
 import { getVectorDistance } from '@/utils/vector';
+import { parseMegaphone } from '@/utils/sessionMegaphone';
 
 const props = defineProps<{
   id: string;
@@ -52,14 +53,15 @@ const distance = computed(() => {
   return getVectorDistance(local.pos, user.value.pos);
 });
 const isOutsideSphere = computed(() => distance.value > 650);
+const isMegaphone = computed(() => parseMegaphone(user.value?.properties?.megaphone));
 const showAvatar = computed(() => {
   if (isStageOccupant.value) return true;
   if (!videoTrack.value) return true;
-  if (isOutsideSphere.value && features.isStageModeActive) return true;
+  if (isOutsideSphere.value && features.isStageModeActive && !isMegaphone.value) return true;
   return false;
 });
 const speaking = computed(() => {
-  if (isOutsideSphere.value && !isPresenter.value) return false;
+  if (isOutsideSphere.value && !isPresenter.value && !isMegaphone.value) return false;
   return !!user.value?.speaking && !user.value?.mute;
 });
 const reaction = computed(() => features.userReactions[props.id]?.emoji);
@@ -89,14 +91,16 @@ const isStageOccupant = computed(() => {
         avatarTile: showAvatar,
         speaking: speaking && showAvatar,
         onStageOccupant: isStageOccupant,
+        megaphone: isMegaphone,
       }"
     >
       <UserBackdrop v-if="showAvatar" :onStage="isStageOccupant" :displayName="user?.user?._displayName || ''" :avatarUrl="(user?.properties?.avatarUrl as string | null | undefined)" />
-      <template v-if="videoTrack && !isStageOccupant && !(isOutsideSphere && features.isStageModeActive)">
+      <template v-if="videoTrack && !isStageOccupant && !(isOutsideSphere && features.isStageModeActive && !isMegaphone)">
         <RemoteVideo :key="videoTrackKey" :id="id" :track="videoTrack" :speaking="speaking" />
       </template>
       <span v-if="reaction" class="floatReact">{{ reaction }}</span>
       <div v-if="handUp" class="handBadge" title="Hand raised">✋</div>
+      <div v-if="isMegaphone" class="megaphoneBadge" title="Speaking to all">📣</div>
     </div>
     <RemoteAudio :id="id" :volume="user?.volume" />
     <MuteIndicator v-if="user.mute" />

--- a/src-vue/components/room/SphereGridOverlay.test.ts
+++ b/src-vue/components/room/SphereGridOverlay.test.ts
@@ -51,6 +51,22 @@ describe('SphereGridOverlay', () => {
     wrapper.unmount();
   });
 
+  it('renders remote cameras with GridTileVideo instead of the bubble player', async () => {
+    const local = useLocalStore();
+    const conference = useConferenceStore();
+    local.setMyID('me');
+    local.pos = { x: 0, y: 0 };
+    local.cameraOff = false;
+    local.video = makeTrack('video');
+    conference.addUser('near', { _displayName: 'Near' } as never);
+    conference.users.near.pos = { x: 8, y: 8 };
+    conference.users.near.video = makeTrack('video');
+    const { wrapper } = await mountWithApp(SphereGridOverlay);
+    expect(wrapper.findAllComponents({ name: 'GridTileVideo' })).toHaveLength(2);
+    expect(wrapper.findComponent({ name: 'RemoteVideo' }).exists()).toBe(false);
+    wrapper.unmount();
+  });
+
   it('includes a far presenter and ignores non-string avatars', async () => {
     const local = useLocalStore();
     const conference = useConferenceStore();

--- a/src-vue/components/room/SphereGridOverlay.test.ts
+++ b/src-vue/components/room/SphereGridOverlay.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+import { mountWithApp } from '@/test/mountApp';
+import { useConferenceStore } from '@/stores/conferenceStore';
+import { useLocalStore } from '@/stores/localStore';
+import { useSessionFeaturesStore } from '@/stores/sessionFeaturesStore';
+import { makeTrack } from '@/test/makeTrack';
+import SphereGridOverlay from './SphereGridOverlay.vue';
+
+describe('SphereGridOverlay', () => {
+  beforeEach(() => setActivePinia(createPinia()));
+
+  it('shows local and in-sphere remotes, then closes', async () => {
+    const local = useLocalStore();
+    const conference = useConferenceStore();
+    const features = useSessionFeaturesStore();
+    local.setMyID('me');
+    local.pos = { x: 0, y: 0 };
+    local.cameraOff = true;
+    conference.displayName = 'Ada';
+    conference.addUser('near', { _displayName: 'Near' } as never);
+    conference.users.near.pos = { x: 10, y: 10 };
+    conference.users.near.video = makeTrack('video');
+    conference.addUser('far', { _displayName: 'Far' } as never);
+    conference.users.far.pos = { x: 3000, y: 3000 };
+    features.gridView = true;
+
+    const { wrapper } = await mountWithApp(SphereGridOverlay);
+    expect(wrapper.text()).toContain('Ada');
+    expect(wrapper.text()).toContain('Near');
+    expect(wrapper.text()).not.toContain('Far');
+    await wrapper.find('[aria-label="Close grid view"]').trigger('click');
+    expect(features.gridView).toBe(false);
+    wrapper.unmount();
+  });
+
+  it('renders local camera and remote avatar fallbacks', async () => {
+    const local = useLocalStore();
+    const conference = useConferenceStore();
+    local.setMyID('me');
+    local.pos = { x: 0, y: 0 };
+    local.cameraOff = false;
+    local.video = makeTrack('video');
+    conference.addUser('near', { _displayName: 'Near' } as never);
+    conference.users.near.pos = { x: 8, y: 8 };
+    conference.users.near.properties = { avatarUrl: 'https://example.test/a.png' };
+
+    const { wrapper } = await mountWithApp(SphereGridOverlay);
+    expect(wrapper.findComponent({ name: 'GridTileVideo' }).exists()).toBe(true);
+    expect(wrapper.findComponent({ name: 'UserBackdrop' }).exists()).toBe(true);
+    wrapper.unmount();
+  });
+
+  it('includes a far presenter and ignores non-string avatars', async () => {
+    const local = useLocalStore();
+    const conference = useConferenceStore();
+    const features = useSessionFeaturesStore();
+    local.setMyID('');
+    local.pos = { x: 0, y: 0 };
+    conference.displayName = '';
+    conference.addUser('stage', { _displayName: 'Host' } as never);
+    conference.users.stage.pos = { x: 4000, y: 4000 };
+    conference.users.stage.properties = { avatarUrl: 1 };
+    features.stageOccupantId = 'stage';
+    const { wrapper } = await mountWithApp(SphereGridOverlay);
+    expect(wrapper.text()).toContain('You');
+    expect(wrapper.text()).toContain('Host');
+    wrapper.unmount();
+  });
+});

--- a/src-vue/components/room/SphereGridOverlay.vue
+++ b/src-vue/components/room/SphereGridOverlay.vue
@@ -1,0 +1,159 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useConferenceStore } from '@/stores/conferenceStore';
+import { useLocalStore } from '@/stores/localStore';
+import { useSessionFeaturesStore } from '@/stores/sessionFeaturesStore';
+import { useAuthStore } from '@/stores/authStore';
+import RemoteVideo from '@/components/room/RemoteVideo.vue';
+import UserBackdrop from '@/components/room/overlays/UserBackdrop.vue';
+import GridTileVideo from '@/components/room/GridTileVideo.vue';
+import { sphereGridMembers } from '@/utils/sphereGrid';
+import IconButton from '@/components/ui/IconButton.vue';
+import AppIcon from '@/components/ui/AppIcon.vue';
+
+const conference = useConferenceStore();
+const local = useLocalStore();
+const features = useSessionFeaturesStore();
+const auth = useAuthStore();
+
+const members = computed(() => {
+  conference.usersEpoch;
+  const remotes = Object.values(conference.users).map((user) => ({
+    id: user.id,
+    pos: user.pos,
+    properties: user.properties,
+    displayName: user.user?._displayName,
+  }));
+  return sphereGridMembers(
+    local.pos,
+    local.id,
+    conference.displayName || 'You',
+    remotes,
+    { presenterId: features.stageOccupantId || undefined },
+  );
+});
+
+const showLocalVideo = computed(() => !!local.video && !local.cameraOff);
+
+function remoteVideo(id: string) {
+  return conference.users[id]?.video;
+}
+
+function remoteAvatar(id: string): string | undefined {
+  const url = conference.users[id]?.properties?.avatarUrl;
+  return typeof url === 'string' ? url : undefined;
+}
+
+function close() {
+  features.gridView = false;
+}
+</script>
+
+<template>
+  <div class="sphereGrid" role="dialog" aria-label="People in your sphere">
+    <div class="gridHeader">
+      <h2>In your sphere</h2>
+      <IconButton label="Close grid view" ghost @click="close">
+        <template #icon><AppIcon name="close" /></template>
+      </IconButton>
+    </div>
+    <div class="gridTiles">
+      <article v-for="member in members" :key="member.id" class="tile">
+        <div class="tileVideo">
+          <template v-if="member.isLocal">
+            <GridTileVideo v-if="showLocalVideo" :track="local.video" muted />
+            <UserBackdrop
+              v-else
+              :displayName="member.displayName"
+              :avatarUrl="auth.user?.avatarUrl"
+            />
+          </template>
+          <template v-else>
+            <RemoteVideo
+              v-if="remoteVideo(member.id)"
+              :id="member.id"
+              :track="remoteVideo(member.id)"
+            />
+            <UserBackdrop
+              v-else
+              :displayName="member.displayName"
+              :avatarUrl="remoteAvatar(member.id)"
+            />
+          </template>
+        </div>
+        <p class="tileName">{{ member.displayName }}</p>
+      </article>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.sphereGrid {
+  position: fixed;
+  inset: 0;
+  z-index: 5500;
+  background: var(--color-mono95, #f4f4f7);
+  display: flex;
+  flex-direction: column;
+  padding: 16px 16px 120px;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+}
+.gridHeader {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+.gridHeader h2 {
+  margin: 0;
+  font-size: var(--fs-h2);
+  font-weight: var(--fw-medium);
+}
+.gridTiles {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+.tile {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+.tileVideo {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 1;
+  border-radius: 16px;
+  overflow: hidden;
+  background: #0f172a;
+}
+.tileName {
+  margin: 0;
+  font-size: 16px;
+  font-weight: var(--fw-medium);
+  text-align: center;
+}
+
+@media (max-width: 768px) {
+  .gridTiles {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .gridHeader :deep(.ibtn) {
+    min-width: 44px;
+    min-height: 44px;
+  }
+}
+
+@media (max-width: 480px) {
+  .gridTiles {
+    grid-template-columns: 1fr;
+  }
+  .sphereGrid {
+    padding: 12px 12px 140px;
+  }
+}
+</style>

--- a/src-vue/components/room/SphereGridOverlay.vue
+++ b/src-vue/components/room/SphereGridOverlay.vue
@@ -4,7 +4,6 @@ import { useConferenceStore } from '@/stores/conferenceStore';
 import { useLocalStore } from '@/stores/localStore';
 import { useSessionFeaturesStore } from '@/stores/sessionFeaturesStore';
 import { useAuthStore } from '@/stores/authStore';
-import RemoteVideo from '@/components/room/RemoteVideo.vue';
 import UserBackdrop from '@/components/room/overlays/UserBackdrop.vue';
 import GridTileVideo from '@/components/room/GridTileVideo.vue';
 import { sphereGridMembers } from '@/utils/sphereGrid';
@@ -69,11 +68,7 @@ function close() {
             />
           </template>
           <template v-else>
-            <RemoteVideo
-              v-if="remoteVideo(member.id)"
-              :id="member.id"
-              :track="remoteVideo(member.id)"
-            />
+            <GridTileVideo v-if="remoteVideo(member.id)" :track="remoteVideo(member.id)" muted />
             <UserBackdrop
               v-else
               :displayName="member.displayName"

--- a/src-vue/components/room/SphereGridOverlay.vue
+++ b/src-vue/components/room/SphereGridOverlay.vue
@@ -53,7 +53,7 @@ function close() {
   <div class="sphereGrid" role="dialog" aria-label="People in your sphere">
     <div class="gridHeader">
       <h2>In your sphere</h2>
-      <IconButton label="Close grid view" ghost @click="close">
+      <IconButton label="Close grid view" @click="close">
         <template #icon><AppIcon name="close" /></template>
       </IconButton>
     </div>
@@ -91,7 +91,7 @@ function close() {
 .sphereGrid {
   position: fixed;
   inset: 0;
-  z-index: 5500;
+  z-index: 6500;
   background: var(--color-mono95, #f4f4f7);
   display: flex;
   flex-direction: column;

--- a/src-vue/components/room/participantTileOverlays.css
+++ b/src-vue/components/room/participantTileOverlays.css
@@ -95,3 +95,22 @@
 .videoContainer.onStageOccupant:not(.desktop) .vid {
   border-color: var(--color-blue100);
 }
+
+.videoContainer.megaphone {
+  transform: scale(1.35);
+  transform-origin: center center;
+  z-index: 6;
+  box-shadow: 0 0 0 6px rgba(79, 110, 247, 0.4);
+}
+
+.megaphoneBadge {
+  position: absolute;
+  bottom: -8px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 1.6rem;
+  line-height: 1;
+  z-index: 10;
+  pointer-events: none;
+  filter: drop-shadow(0 2px 6px rgba(0, 0, 0, 0.45));
+}

--- a/src-vue/components/runtime/applyWorkerVolume.test.ts
+++ b/src-vue/components/runtime/applyWorkerVolume.test.ts
@@ -18,4 +18,11 @@ describe('applyWorkerVolume', () => {
     applyWorkerVolume('known', 0.8, users, vi.fn(), setVolume);
     expect(setVolume).toHaveBeenCalledWith('known', 0);
   });
+
+  it('forces full gain when the participant has megaphone', () => {
+    const users = { known: { mute: false, properties: { megaphone: true } } };
+    const setVolume = vi.fn();
+    applyWorkerVolume('known', 0.2, users, vi.fn(), setVolume);
+    expect(setVolume).toHaveBeenCalledWith('known', 1);
+  });
 });

--- a/src-vue/components/runtime/applyWorkerVolume.ts
+++ b/src-vue/components/runtime/applyWorkerVolume.ts
@@ -1,6 +1,6 @@
 import { playbackGainForUser } from '@/utils/participantPlaybackGain';
 
-export type ProximityUser = { mute: boolean };
+export type ProximityUser = { mute?: boolean; properties?: Record<string, unknown> };
 
 /** Apply a proximity volume update when the participant is known. */
 export function applyWorkerVolume(

--- a/src-vue/components/session/SessionTools.test.ts
+++ b/src-vue/components/session/SessionTools.test.ts
@@ -59,6 +59,12 @@ describe('SessionTools', () => {
     expect(features.handRaised).toBe(true);
     expect(propSpy).toHaveBeenCalledWith('handRaised', true);
     expect(cmdSpy).toHaveBeenCalledWith('hand', JSON.stringify({ id: 'local-1', raised: true }));
+    await wrapper.find('[aria-label="Speak to all"]').trigger('click');
+    expect(features.megaphone).toBe(true);
+    expect(propSpy).toHaveBeenCalledWith('megaphone', true);
+    expect(cmdSpy).toHaveBeenCalledWith('megaphone', JSON.stringify({ id: 'local-1', on: true }));
+    await wrapper.find('[aria-label="Stop speaking to all"]').trigger('click');
+    expect(features.megaphone).toBe(false);
     await wrapper.find('[aria-label="Poll"]').trigger('click');
     expect(features.panel).toBe('poll');
     await wrapper.find('[aria-label="Shared notes"]').trigger('click');
@@ -192,6 +198,30 @@ describe('SessionTools', () => {
     const { wrapper } = await mountWithApp(SessionTools);
     await wrapper.find('[aria-label="Raise hand"]').trigger('click');
     expect(useSessionFeaturesStore().handRaised).toBe(true);
+    wrapper.unmount();
+  });
+
+  it('toggles megaphone using the engine user id when local id is unset', async () => {
+    const local = useLocalStore();
+    local.setMyID('');
+    vi.spyOn(getMediaEngineInstance(), 'getLocalUserId').mockReturnValue('engine-user');
+    const propSpy = vi.spyOn(getMediaEngineInstance(), 'setLocalParticipantProperty');
+    const { wrapper } = await mountWithApp(SessionTools);
+    await wrapper.find('[aria-label="Speak to all"]').trigger('click');
+    expect(propSpy).toHaveBeenCalledWith('megaphone', true);
+    expect(useSessionFeaturesStore().megaphone).toBe(true);
+    wrapper.unmount();
+  });
+
+  it('ignores megaphone toggle when no participant id is available', async () => {
+    const local = useLocalStore();
+    local.setMyID('');
+    const propSpy = vi.spyOn(getMediaEngineInstance(), 'setLocalParticipantProperty');
+    vi.spyOn(getMediaEngineInstance(), 'getLocalUserId').mockReturnValue(undefined);
+    const { wrapper } = await mountWithApp(SessionTools);
+    await wrapper.find('[aria-label="Speak to all"]').trigger('click');
+    expect(propSpy).not.toHaveBeenCalled();
+    expect(useSessionFeaturesStore().megaphone).toBe(false);
     wrapper.unmount();
   });
 });

--- a/src-vue/components/session/SessionTools.test.ts
+++ b/src-vue/components/session/SessionTools.test.ts
@@ -224,4 +224,17 @@ describe('SessionTools', () => {
     expect(useSessionFeaturesStore().megaphone).toBe(false);
     wrapper.unmount();
   });
+
+  it('toggles grid view locally without a conference command', async () => {
+    const features = useSessionFeaturesStore();
+    const cmdSpy = vi.spyOn(getMediaEngineInstance(), 'sendCommand');
+    const { wrapper } = await mountWithApp(SessionTools);
+    await wrapper.find('[aria-label="Grid view"]').trigger('click');
+    expect(features.gridView).toBe(true);
+    expect(wrapper.find('[aria-label="Exit grid view"]').classes()).toContain('highlight');
+    expect(cmdSpy).not.toHaveBeenCalled();
+    await wrapper.find('[aria-label="Exit grid view"]').trigger('click');
+    expect(features.gridView).toBe(false);
+    wrapper.unmount();
+  });
 });

--- a/src-vue/components/session/SessionTools.vue
+++ b/src-vue/components/session/SessionTools.vue
@@ -13,6 +13,7 @@ import { useMediaEngine } from '@/composables/useMediaEngine';
 import { sendSessionReaction } from '@/utils/sessionReactions';
 import { playUiSound } from '@/utils/uiSounds';
 import { applyParticipantHandRaised } from '@/utils/sessionHandRaise';
+import { applyParticipantMegaphone } from '@/utils/sessionMegaphone';
 
 const features = useSessionFeaturesStore();
 const local = useLocalStore();
@@ -26,6 +27,16 @@ function toggleHand() {
   engine.setLocalParticipantProperty('handRaised', raised);
   engine.sendCommand('hand', JSON.stringify({ id, raised }));
   applyParticipantHandRaised(id, raised);
+}
+
+function toggleMegaphone() {
+  const id = local.id || engine.getLocalUserId();
+  if (!id) return;
+  const on = !features.megaphone;
+  features.megaphone = on;
+  engine.setLocalParticipantProperty('megaphone', on);
+  engine.sendCommand('megaphone', JSON.stringify({ id, on }));
+  applyParticipantMegaphone(id, on);
 }
 
 function toggleReactions() {
@@ -75,6 +86,14 @@ function openPanel(name: 'notes' | 'whiteboard') {
       @click="toggleHand"
     >
       <template #icon><AppIcon name="hand" /></template>
+    </IconButton>
+    <IconButton
+      :label="features.megaphone ? 'Stop speaking to all' : 'Speak to all'"
+      :highlight="features.megaphone"
+      :sound="features.megaphone ? 'toggleOff' : 'toggleOn'"
+      @click="toggleMegaphone"
+    >
+      <template #icon><AppIcon name="megaphone" /></template>
     </IconButton>
     <div v-if="features.canUsePoll || features.isHost || features.isModerator" class="toolWrap">
       <IconButton

--- a/src-vue/components/session/SessionTools.vue
+++ b/src-vue/components/session/SessionTools.vue
@@ -95,6 +95,14 @@ function openPanel(name: 'notes' | 'whiteboard') {
     >
       <template #icon><AppIcon name="megaphone" /></template>
     </IconButton>
+    <IconButton
+      :label="features.gridView ? 'Exit grid view' : 'Grid view'"
+      :highlight="features.gridView"
+      :sound="features.gridView ? 'toggleOff' : 'toggleOn'"
+      @click="features.gridView = !features.gridView"
+    >
+      <template #icon><AppIcon name="layout-grid" /></template>
+    </IconButton>
     <div v-if="features.canUsePoll || features.isHost || features.isModerator" class="toolWrap">
       <IconButton
         label="Poll"

--- a/src-vue/components/ui/AppIcon.test.ts
+++ b/src-vue/components/ui/AppIcon.test.ts
@@ -25,6 +25,8 @@ const ICON_NAMES: IconName[] = [
   'video',
   'video-off',
   'volume-x',
+  'megaphone',
+  'layout-grid',
 ];
 
 describe('AppIcon', () => {

--- a/src-vue/components/ui/AppIcon.vue
+++ b/src-vue/components/ui/AppIcon.vue
@@ -36,6 +36,8 @@ import {
   Settings,
   AlertTriangle,
   Download,
+  Megaphone,
+  LayoutGrid,
 } from '@lucide/vue';
 
 const props = withDefaults(
@@ -82,7 +84,9 @@ export type IconName =
   | 'info'
   | 'settings'
   | 'alert-triangle'
-  | 'download';
+  | 'download'
+  | 'megaphone'
+  | 'layout-grid';
 
 const registry: Record<IconName, Component> = {
   'arrow-right': ArrowRight,
@@ -120,6 +124,8 @@ const registry: Record<IconName, Component> = {
   settings: Settings,
   'alert-triangle': AlertTriangle,
   download: Download,
+  megaphone: Megaphone,
+  'layout-grid': LayoutGrid,
 };
 
 const icon = computed(() => registry[props.name]);

--- a/src-vue/composables/ensureLocalTracks.test.ts
+++ b/src-vue/composables/ensureLocalTracks.test.ts
@@ -4,7 +4,10 @@ import { ensureLocalTracks } from './ensureLocalTracks';
 import { useLocalStore } from '@/stores/localStore';
 
 describe('ensureLocalTracks', () => {
-  beforeEach(() => setActivePinia(createPinia()));
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    localStorage.removeItem('loungemesh.mediaDevices');
+  });
 
   it('requests audio and video together when both are missing', async () => {
     const local = useLocalStore();
@@ -95,5 +98,22 @@ describe('ensureLocalTracks', () => {
     await ensureLocalTracks(local, engine as never);
     expect(local.video).toBeUndefined();
     expect(dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes stored device ids when requesting tracks', async () => {
+    const { saveMediaDevicePrefs } = await import('@/utils/mediaDevicePrefs');
+    saveMediaDevicePrefs({ audioinput: 'mic-1', videoinput: 'cam-1', audiooutput: 'spk-1' });
+    const local = useLocalStore();
+    const engine = {
+      createLocalTracks: vi.fn().mockResolvedValue([
+        { getType: () => 'audio' },
+        { getType: () => 'video', videoType: 'camera' },
+      ]),
+    };
+    await ensureLocalTracks(local, engine as never);
+    expect(engine.createLocalTracks).toHaveBeenCalledWith(['audio', 'video'], {
+      audioDeviceId: 'mic-1',
+      videoDeviceId: 'cam-1',
+    });
   });
 });

--- a/src-vue/composables/ensureLocalTracks.ts
+++ b/src-vue/composables/ensureLocalTracks.ts
@@ -4,6 +4,9 @@ import type { useLocalStore } from '@/stores/localStore';
 import { disposeJitsiTrack } from '@/utils/disposeJitsiTrack';
 import { mediaDebug } from '@/utils/mediaDebug';
 import { unlockMediaPlaybackNow } from '@/utils/resumeMediaPlayback';
+import { createPreferredLocalTracks } from '@/utils/createPreferredLocalTracks';
+import { applyAudioOutput } from '@/utils/applyAudioOutput';
+import { loadMediaDevicePrefs } from '@/utils/mediaDevicePrefs';
 
 type LocalStore = ReturnType<typeof useLocalStore>;
 
@@ -19,7 +22,7 @@ export async function ensureLocalTracks(
   if (!devices.length) return existing;
   let tracks: JitsiTrack[] = [];
   try {
-    tracks = await engine.createLocalTracks(devices);
+    tracks = await createPreferredLocalTracks(engine, devices);
     if (devices.includes('audio')) {
       local.audioError = !tracks.some(t => t.getType?.() === 'audio');
     }
@@ -50,6 +53,8 @@ export async function ensureLocalTracks(
     if (!used.has(track)) disposeJitsiTrack(track);
   }
   local.setLocalTracks(merged);
+  const outputId = loadMediaDevicePrefs().audiooutput;
+  if (outputId) await applyAudioOutput(outputId);
   mediaDebug('ensureLocalTracks', 'created', {
     devices,
     audio: !!local.audio,

--- a/src-vue/composables/mediaEngineWiring.test.ts
+++ b/src-vue/composables/mediaEngineWiring.test.ts
@@ -131,6 +131,20 @@ describe('wireStoreSync', () => {
     expect(features.handRaised).toBe(false);
   });
 
+  it('syncs megaphone without creating unknown users', () => {
+    const engine = getMediaEngineInstance();
+    const conference = useConferenceStore();
+    const features = useSessionFeaturesStore();
+    wireStoreSync(engine);
+    (engine as unknown as { emit: (event: string, ...args: unknown[]) => void }).emit(
+      'participantPropertyChanged',
+      'stranger',
+      { megaphone: true },
+    );
+    expect(conference.users.stranger).toBeUndefined();
+    expect(features.megaphone).toBe(false);
+  });
+
   it('syncs speaking participant property', async () => {
     const engine = getMediaEngineInstance();
     const conference = useConferenceStore();
@@ -156,6 +170,11 @@ describe('wireStoreSync', () => {
       _properties: { handRaised: true },
     });
     expect(conference.users.u1.properties.handRaised).toBe(true);
+    jitsi.conference._fire(ev.conference.PARTICIPANT_PROPERTY_CHANGED, {
+      _id: 'u1',
+      _properties: { megaphone: true },
+    });
+    expect(conference.users.u1.properties.megaphone).toBe(true);
   });
 
   it('does not store muted video on trackAdded', async () => {
@@ -520,9 +539,10 @@ describe('wireStoreSync', () => {
     jitsi.connection._fire(ev.connection.CONNECTION_ESTABLISHED);
     await engine.joinRoom('room', 'Alice', {});
     jitsi.conference._fire(ev.conference.USER_JOINED, 'guest', {
-      _properties: { handRaised: true },
+      _properties: { handRaised: true, megaphone: true },
     });
     expect(conference.users.guest.properties.handRaised).toBe(true);
+    expect(conference.users.guest.properties.megaphone).toBe(true);
   });
 
   it('rebroadcasts access when host sees a new participant', async () => {

--- a/src-vue/composables/mediaEngineWiring.ts
+++ b/src-vue/composables/mediaEngineWiring.ts
@@ -16,6 +16,7 @@ import { emitMediaStateSnapshot } from '@/utils/mediaStateSnapshot';
 import { normalizeSessionError } from '@/services/sessionErrorCodes';
 import { unlockMediaPlaybackNow } from '@/utils/resumeMediaPlayback';
 import { applyParticipantHandRaised, parseHandRaised } from '@/utils/sessionHandRaise';
+import { applyParticipantMegaphone, parseMegaphone } from '@/utils/sessionMegaphone';
 import { broadcastHostRoomSettings } from '@/utils/hostRoomSettings';
 import { broadcastSharedNotes } from '@/utils/notesSync';
 import { isOnStage } from '@/components/stage/isOnStage';
@@ -91,6 +92,9 @@ export function wireStoreSync(engine: MediaService): void {
     );
     if ('handRaised' in props) {
       applyParticipantHandRaised(id, parseHandRaised(props.handRaised));
+    }
+    if ('megaphone' in props) {
+      applyParticipantMegaphone(id, parseMegaphone(props.megaphone));
     }
     const features = useSessionFeaturesStore();
     if (features.isHost) {
@@ -239,6 +243,10 @@ export function wireStoreSync(engine: MediaService): void {
     if ('handRaised' in safe) {
       applyParticipantHandRaised(id, parseHandRaised(safe.handRaised));
       delete safe.handRaised;
+    }
+    if ('megaphone' in safe) {
+      applyParticipantMegaphone(id, parseMegaphone(safe.megaphone));
+      delete safe.megaphone;
     }
     if ('onStage' in safe) {
       const features = useSessionFeaturesStore();

--- a/src-vue/pages/EnterPage.vue
+++ b/src-vue/pages/EnterPage.vue
@@ -53,7 +53,7 @@ onBeforeUnmount(() => {
 <template>
   <AppHeader />
   <LocalStoreLogic />
-  <PanWrapper>
+  <PanWrapper :show-grid="false">
     <Room>
       <LocalUser />
     </Room>

--- a/src-vue/pages/EnterPage.vue
+++ b/src-vue/pages/EnterPage.vue
@@ -15,6 +15,7 @@ import { useMediaEngine } from '@/composables/useMediaEngine';
 import { ensureLocalTracks } from '@/composables/ensureLocalTracks';
 import { joinFromEnterPage } from '@/utils/enterPageJoin';
 import AppIcon from '@/components/ui/AppIcon.vue';
+import DeviceSettingsButton from '@/components/footer/DeviceSettingsButton.vue';
 import { playUiSound } from '@/utils/uiSounds';
 
 const props = defineProps<{ id: string }>();
@@ -84,6 +85,7 @@ onBeforeUnmount(() => {
         <AppIcon :name="local.mute ? 'mic-off' : 'mic'" />
       </template>
     </IconButton>
+    <DeviceSettingsButton />
     <button type="button" class="btn-primary-round" @click="join">
       <AppIcon name="arrow-right" class="join-ico" />
       Join

--- a/src-vue/pages/EnterPage.vue
+++ b/src-vue/pages/EnterPage.vue
@@ -53,7 +53,7 @@ onBeforeUnmount(() => {
 <template>
   <AppHeader />
   <LocalStoreLogic />
-  <PanWrapper :show-grid="false">
+  <PanWrapper>
     <Room>
       <LocalUser />
     </Room>

--- a/src-vue/pages/SessionPage.test.ts
+++ b/src-vue/pages/SessionPage.test.ts
@@ -135,6 +135,7 @@ const sessionStubs = {
   LobbyOverlay: { template: '<div />' },
   ChatPanel: { template: '<div class="chat-stub" />' },
   WhiteboardOverlay: { template: '<div />' },
+  SphereGridOverlay: { template: '<div class="sphere-grid-stub" />' },
 };
 
 describe('SessionPage', () => {
@@ -142,6 +143,19 @@ describe('SessionPage', () => {
 
   afterEach(async () => {
     await flushPromises();
+  });
+
+  it('shows the sphere grid overlay when grid view is on', async () => {
+    const features = useSessionFeaturesStore();
+    features.gridView = true;
+    const { wrapper } = await mountWithApp(SessionPage, {
+      route: '/session/loungemesh',
+      props: { id: 'loungemesh' },
+      global: { stubs: sessionStubs },
+    });
+    await flushPromises();
+    expect(wrapper.find('.sphere-grid-stub').exists()).toBe(true);
+    wrapper.unmount();
   });
 
   it('hides shared screens while stage mode is active', async () => {

--- a/src-vue/pages/SessionPage.vue
+++ b/src-vue/pages/SessionPage.vue
@@ -13,6 +13,8 @@ import AppHeader from '@/components/layout/AppHeader.vue';
 import ErrorHandler from '@/components/common/ErrorHandler.vue';
 import { defineAsyncComponent } from 'vue';
 import ScreenshareButton from '@/components/footer/ScreenshareButton.vue';
+import DeviceSettingsButton from '@/components/footer/DeviceSettingsButton.vue';
+import SphereGridOverlay from '@/components/room/SphereGridOverlay.vue';
 import SharedScreens from '@/components/screenshare/SharedScreens.vue';
 import { demoteFromStage, applyStagePromote, broadcastStageLayout } from '@/utils/sessionStage';
 import { getMediaEngineInstance } from '@/services/mediaEngineSingleton';
@@ -189,6 +191,7 @@ onBeforeUnmount(() => {
       <LocalUser />
     </Room>
   </PanWrapper>
+  <SphereGridOverlay v-if="features.gridView" />
   <SharedScreens v-if="!features.isStageModeActive" />
   <SessionFeaturePanels />
   <WhiteboardOverlay
@@ -300,6 +303,7 @@ onBeforeUnmount(() => {
         <AppIcon :name="local.mute ? 'mic-off' : 'mic'" />
       </template>
     </IconButton>
+    <DeviceSettingsButton />
     <ScreenshareButton />
     <IconButton
       v-if="features.stageInvitationPending || features.isLocalStageOccupant"

--- a/src-vue/services/JitsiAdapter.test.ts
+++ b/src-vue/services/JitsiAdapter.test.ts
@@ -379,6 +379,37 @@ describe('JitsiAdapter', () => {
     expect(mock.jsMeet.createLocalTracks).toHaveBeenCalledWith(
       expect.objectContaining({ devices: ['video'] }),
     );
+    await adapter.createLocalTracks(['audio'], { audioDeviceId: 'mic-1' });
+    expect(mock.jsMeet.createLocalTracks).toHaveBeenCalledWith(
+      expect.objectContaining({
+        devices: ['audio'],
+        micDeviceId: 'mic-1',
+        constraints: expect.objectContaining({
+          audio: expect.objectContaining({ deviceId: { exact: 'mic-1' } }),
+        }),
+      }),
+    );
+    await adapter.createLocalTracks(['video'], { videoDeviceId: 'cam-1' });
+    expect(mock.jsMeet.createLocalTracks).toHaveBeenCalledWith(
+      expect.objectContaining({
+        devices: ['video'],
+        cameraDeviceId: 'cam-1',
+        constraints: expect.objectContaining({
+          video: { deviceId: { exact: 'cam-1' } },
+        }),
+      }),
+    );
+    await adapter.createLocalTracks(['audio', 'video'], {
+      audioDeviceId: 'mic-1',
+      videoDeviceId: 'cam-1',
+    });
+    expect(mock.jsMeet.createLocalTracks).toHaveBeenCalledWith(
+      expect.objectContaining({
+        devices: ['audio', 'video'],
+        micDeviceId: 'mic-1',
+        cameraDeviceId: 'cam-1',
+      }),
+    );
     await adapter.replaceLocalTrack(tracks[0], tracks[0]);
     adapter.setDisplayName('A');
     adapter.setLocalParticipantProperty('k', 'v');

--- a/src-vue/services/JitsiAdapter.ts
+++ b/src-vue/services/JitsiAdapter.ts
@@ -296,6 +296,7 @@ export class JitsiAdapter implements MediaService {
       'lobby',
       'react',
       'hand',
+      'megaphone',
       'poll',
       'notes',
       'room',
@@ -330,7 +331,10 @@ export class JitsiAdapter implements MediaService {
     this.addedLocalTracks.clear();
   }
 
-  async createLocalTracks(devices: ('audio' | 'video' | 'desktop')[]): Promise<JitsiTrack[]> {
+  async createLocalTracks(
+    devices: ('audio' | 'video' | 'desktop')[],
+    deviceIds?: { audioDeviceId?: string; videoDeviceId?: string },
+  ): Promise<JitsiTrack[]> {
     this.init();
     const options = { firePermissionPromptIsShownEvent: true };
     if (devices.includes('desktop')) {
@@ -341,20 +345,27 @@ export class JitsiAdapter implements MediaService {
       } as any);
     }
     const av = devices.filter((d): d is 'audio' | 'video' => d === 'audio' || d === 'video');
-    const trackOptions: any = {
+    const trackOptions: Record<string, unknown> = {
       devices: av.length ? av : ['video'],
       ...options,
     };
+    if (deviceIds?.audioDeviceId) trackOptions.micDeviceId = deviceIds.audioDeviceId;
+    if (deviceIds?.videoDeviceId) trackOptions.cameraDeviceId = deviceIds.videoDeviceId;
+    const constraints: Record<string, unknown> = {};
     if (devices.includes('audio')) {
-      trackOptions.constraints = {
-        audio: {
-          echoCancellation: true,
-          noiseSuppression: true,
-          autoGainControl: true,
-        }
+      const audio: Record<string, unknown> = {
+        echoCancellation: true,
+        noiseSuppression: true,
+        autoGainControl: true,
       };
+      if (deviceIds?.audioDeviceId) audio.deviceId = { exact: deviceIds.audioDeviceId };
+      constraints.audio = audio;
     }
-    return this.jsMeet!.createLocalTracks(trackOptions);
+    if (deviceIds?.videoDeviceId) {
+      constraints.video = { deviceId: { exact: deviceIds.videoDeviceId } };
+    }
+    if (Object.keys(constraints).length) trackOptions.constraints = constraints;
+    return this.jsMeet!.createLocalTracks(trackOptions as Parameters<JitsiMeetJS['createLocalTracks']>[0]);
   }
 
   async addLocalTrack(track: JitsiTrack): Promise<void> {
@@ -493,7 +504,7 @@ export class JitsiAdapter implements MediaService {
   sendCommand(name: string, value: string): void {
     if (!this.conference) return;
     this.conference.sendCommand(name, { value: encodeXmppCommandValue(value) });
-    if (name === 'stage' || name === 'react' || name === 'mod' || name === 'hand') {
+    if (name === 'stage' || name === 'react' || name === 'mod' || name === 'hand' || name === 'megaphone') {
       try {
         this.conference.removeCommand(name);
       } catch (e) {

--- a/src-vue/services/MediaService.ts
+++ b/src-vue/services/MediaService.ts
@@ -58,7 +58,10 @@ export interface MediaService {
   disconnect(): void;
   joinRoom(room: string, displayName: string, conferenceOptions: Record<string, unknown>): Promise<void>;
   leaveRoom(): void;
-  createLocalTracks(devices: ('audio' | 'video' | 'desktop')[]): Promise<MediaTrackHandle[]>;
+  createLocalTracks(
+    devices: ('audio' | 'video' | 'desktop')[],
+    deviceIds?: { audioDeviceId?: string; videoDeviceId?: string },
+  ): Promise<MediaTrackHandle[]>;
   addLocalTrack(track: MediaTrackHandle): Promise<void>;
   removeLocalTrack?(track: MediaTrackHandle): Promise<void>;
   replaceLocalTrack(oldTrack: MediaTrackHandle, newTrack: MediaTrackHandle): Promise<void>;

--- a/src-vue/stores/localStore.test.ts
+++ b/src-vue/stores/localStore.test.ts
@@ -8,7 +8,9 @@ import { getMediaEngineInstance } from '@/services/mediaEngineSingleton';
 
 describe('localStore', () => {
   beforeEach(() => {
+    vi.restoreAllMocks();
     setActivePinia(createPinia());
+    localStorage.removeItem('loungemesh.mediaDevices');
   });
 
   it('expands room bounds when users move far from the center', () => {
@@ -644,5 +646,150 @@ describe('localStore', () => {
     store.onStage = true;
     store.calculateUsersOnScreen();
     el.remove();
+  });
+
+  it('switchAudioInput persists prefs and skips when muted', async () => {
+    const store = useLocalStore();
+    store.mute = true;
+    store.audio = undefined;
+    await store.switchAudioInput('mic-9');
+    const { loadMediaDevicePrefs } = await import('@/utils/mediaDevicePrefs');
+    expect(loadMediaDevicePrefs().audioinput).toBe('mic-9');
+  });
+
+  it('switchAudioInput replaces a live track while joined', async () => {
+    const old = { getType: () => 'audio', dispose: vi.fn() };
+    const created = { getType: () => 'audio', dispose: vi.fn() };
+    const engine = getMediaEngineInstance();
+    vi.spyOn(engine, 'isJoined').mockReturnValue(true);
+    vi.spyOn(engine, 'createLocalTracks').mockResolvedValue([created as never]);
+    const replace = vi.spyOn(engine, 'replaceLocalTrack').mockResolvedValue(undefined);
+    const store = useLocalStore();
+    store.audio = old as never;
+    store.mute = false;
+    await store.switchAudioInput('mic-2');
+    expect(replace).toHaveBeenCalledWith(old, created);
+    expect(store.audio).toBeTruthy();
+    expect(store.mute).toBe(false);
+  });
+
+  it('switchAudioInput disposes the new track when replace fails', async () => {
+    const old = { getType: () => 'audio', dispose: vi.fn() };
+    const created = { getType: () => 'audio', dispose: vi.fn() };
+    const engine = getMediaEngineInstance();
+    vi.spyOn(engine, 'isJoined').mockReturnValue(true);
+    vi.spyOn(engine, 'createLocalTracks').mockResolvedValue([created as never]);
+    vi.spyOn(engine, 'replaceLocalTrack').mockRejectedValue(new Error('busy'));
+    const store = useLocalStore();
+    store.audio = old as never;
+    store.mute = false;
+    await store.switchAudioInput('mic-3');
+    expect(created.dispose).toHaveBeenCalled();
+    expect(toRaw(store.audio)).toBe(old);
+  });
+
+  it('switchAudioInput swaps preview tracks when not joined', async () => {
+    const old = { getType: () => 'audio', dispose: vi.fn() };
+    const created = { getType: () => 'audio', dispose: vi.fn() };
+    const engine = getMediaEngineInstance();
+    vi.spyOn(engine, 'isJoined').mockReturnValue(false);
+    vi.spyOn(engine, 'createLocalTracks').mockResolvedValue([created as never]);
+    const store = useLocalStore();
+    store.audio = old as never;
+    store.mute = false;
+    await store.switchAudioInput('mic-4');
+    expect(store.audio).toBeTruthy();
+    expect(old.dispose).toHaveBeenCalled();
+  });
+
+  it('switchAudioInput no-ops on empty create and records errors', async () => {
+    const old = { getType: () => 'audio', dispose: vi.fn() };
+    const engine = getMediaEngineInstance();
+    vi.spyOn(engine, 'isJoined').mockReturnValue(false);
+    const create = vi.spyOn(engine, 'createLocalTracks').mockResolvedValue([]);
+    const store = useLocalStore();
+    store.audio = old as never;
+    store.mute = false;
+    await store.switchAudioInput('mic-5');
+    expect(toRaw(store.audio)).toBe(old);
+    create.mockRejectedValue(new Error('denied'));
+    await store.switchAudioInput('mic-6');
+    expect(store.audioError).toBe(true);
+  });
+
+  it('switchVideoInput persists prefs and skips when camera is off', async () => {
+    const store = useLocalStore();
+    store.cameraOff = true;
+    store.video = undefined;
+    await store.switchVideoInput('cam-9');
+    const { loadMediaDevicePrefs } = await import('@/utils/mediaDevicePrefs');
+    expect(loadMediaDevicePrefs().videoinput).toBe('cam-9');
+  });
+
+  it('switchVideoInput replaces a live camera while joined', async () => {
+    const old = { getType: () => 'video', dispose: vi.fn() };
+    const created = { getType: () => 'video', dispose: vi.fn() };
+    const engine = getMediaEngineInstance();
+    vi.spyOn(engine, 'isJoined').mockReturnValue(true);
+    vi.spyOn(engine, 'createLocalTracks').mockResolvedValue([created as never]);
+    const replace = vi.spyOn(engine, 'replaceLocalTrack').mockResolvedValue(undefined);
+    const store = useLocalStore();
+    store.video = old as never;
+    store.cameraOff = false;
+    await store.switchVideoInput('cam-2');
+    expect(replace).toHaveBeenCalledWith(old, created);
+    expect(store.video).toBeTruthy();
+    expect(store.cameraOff).toBe(false);
+  });
+
+  it('switchVideoInput disposes the new track when replace fails', async () => {
+    const old = { getType: () => 'video', dispose: vi.fn() };
+    const created = { getType: () => 'video', dispose: vi.fn() };
+    const engine = getMediaEngineInstance();
+    vi.spyOn(engine, 'isJoined').mockReturnValue(true);
+    vi.spyOn(engine, 'createLocalTracks').mockResolvedValue([created as never]);
+    vi.spyOn(engine, 'replaceLocalTrack').mockRejectedValue(new Error('busy'));
+    const store = useLocalStore();
+    store.video = old as never;
+    store.cameraOff = false;
+    await store.switchVideoInput('cam-3');
+    expect(created.dispose).toHaveBeenCalled();
+    expect(toRaw(store.video)).toBe(old);
+  });
+
+  it('switchVideoInput swaps preview tracks when not joined', async () => {
+    const old = { getType: () => 'video', dispose: vi.fn() };
+    const created = { getType: () => 'video', dispose: vi.fn() };
+    const engine = getMediaEngineInstance();
+    vi.spyOn(engine, 'isJoined').mockReturnValue(false);
+    vi.spyOn(engine, 'createLocalTracks').mockResolvedValue([created as never]);
+    const store = useLocalStore();
+    store.video = old as never;
+    store.cameraOff = false;
+    await store.switchVideoInput('cam-4');
+    expect(store.video).toBeTruthy();
+    expect(old.dispose).toHaveBeenCalled();
+  });
+
+  it('switchVideoInput no-ops on empty create and records errors', async () => {
+    const old = { getType: () => 'video', dispose: vi.fn() };
+    const engine = getMediaEngineInstance();
+    vi.spyOn(engine, 'isJoined').mockReturnValue(false);
+    const create = vi.spyOn(engine, 'createLocalTracks').mockResolvedValue([]);
+    const store = useLocalStore();
+    store.video = old as never;
+    store.cameraOff = false;
+    await store.switchVideoInput('cam-5');
+    expect(toRaw(store.video)).toBe(old);
+    create.mockRejectedValue(new Error('denied'));
+    await store.switchVideoInput('cam-6');
+    expect(store.videoError).toBe(true);
+  });
+
+  it('switchAudioOutput persists the sink id', async () => {
+    const store = useLocalStore();
+    await store.switchAudioOutput('spk-1');
+    const { loadMediaDevicePrefs } = await import('@/utils/mediaDevicePrefs');
+    expect(loadMediaDevicePrefs().audiooutput).toBe('spk-1');
   });
 });

--- a/src-vue/stores/localStore.ts
+++ b/src-vue/stores/localStore.ts
@@ -36,6 +36,9 @@ import { mediaDebug } from '@/utils/mediaDebug';
 import { unlockMediaPlaybackNow } from '@/utils/resumeMediaPlayback';
 import { useConferenceStore } from './conferenceStore';
 import { useSessionFeaturesStore } from './sessionFeaturesStore';
+import { saveMediaDevicePrefs } from '@/utils/mediaDevicePrefs';
+import { createPreferredLocalTracks } from '@/utils/createPreferredLocalTracks';
+import { applyAudioOutput } from '@/utils/applyAudioOutput';
 
 function uniqueTracks(tracks: Array<JitsiTrack | undefined>): JitsiTrack[] {
   return [...new Set(tracks.filter(Boolean) as JitsiTrack[])];
@@ -251,7 +254,7 @@ export const useLocalStore = defineStore('local', {
         return;
       }
       try {
-        const tracks = await engine.createLocalTracks(['audio']);
+        const tracks = await createPreferredLocalTracks(engine, ['audio']);
         const created = tracks.find((t) => t.getType() === 'audio');
         if (!created) return;
         const conf = engine.getConference();
@@ -315,7 +318,7 @@ export const useLocalStore = defineStore('local', {
         return;
       }
       try {
-        const tracks = await engine.createLocalTracks(['video']);
+        const tracks = await createPreferredLocalTracks(engine, ['video']);
         const created = tracks.find((t) => t.getType() === 'video');
         if (!created) return;
         const conf = engine.getConference();
@@ -353,6 +356,62 @@ export const useLocalStore = defineStore('local', {
       await waitForMediaElementDetach();
       await releaseLocalMediaTracks(tracksToRelease, conf);
       stopMediaStreamTracks(rawTracks);
+    },
+    async switchAudioInput(deviceId: string) {
+      saveMediaDevicePrefs({ audioinput: deviceId });
+      if (!this.audio || this.mute) return;
+      const engine = getMediaEngineInstance();
+      try {
+        const tracks = await engine.createLocalTracks(['audio'], { audioDeviceId: deviceId });
+        const created = tracks.find((t) => t.getType() === 'audio');
+        if (!created) return;
+        const old = this.audio;
+        if (engine.isJoined()) {
+          try {
+            await engine.replaceLocalTrack(old, created);
+          } catch {
+            disposeJitsiTrack(created);
+            return;
+          }
+        }
+        disposeJitsiTrack(old);
+        this.audio = markRaw(created);
+        this.mute = false;
+        this.audioError = false;
+        engine.refreshRemoteAudio?.();
+      } catch {
+        this.audioError = true;
+      }
+    },
+    async switchVideoInput(deviceId: string) {
+      saveMediaDevicePrefs({ videoinput: deviceId });
+      if (!this.video || this.cameraOff) return;
+      const engine = getMediaEngineInstance();
+      try {
+        const tracks = await engine.createLocalTracks(['video'], { videoDeviceId: deviceId });
+        const created = tracks.find((t) => t.getType() === 'video');
+        if (!created) return;
+        const old = this.video;
+        if (engine.isJoined()) {
+          try {
+            await engine.replaceLocalTrack(old, created);
+          } catch {
+            disposeJitsiTrack(created);
+            return;
+          }
+        }
+        disposeJitsiTrack(old);
+        this.video = markRaw(created);
+        this.videoType = 'camera';
+        this.cameraOff = false;
+        this.videoError = false;
+      } catch {
+        this.videoError = true;
+      }
+    },
+    async switchAudioOutput(deviceId: string) {
+      saveMediaDevicePrefs({ audiooutput: deviceId });
+      await applyAudioOutput(deviceId);
     },
     async stopAllLocalMedia() {
       const engine = getMediaEngineInstance();

--- a/src-vue/stores/sessionFeaturesStore.ts
+++ b/src-vue/stores/sessionFeaturesStore.ts
@@ -69,6 +69,8 @@ export const useSessionFeaturesStore = defineStore('sessionFeatures', {
     localLobbyPending: false,
     lobbyRejected: false,
     handRaised: false,
+    megaphone: false,
+    gridView: false,
     userReactions: {} as Record<string, UserReaction>,
     activePoll: null as ActivePoll | null,
     myPollVote: '',

--- a/src-vue/types/jitsi.ts
+++ b/src-vue/types/jitsi.ts
@@ -103,6 +103,9 @@ export interface JitsiMeetJS {
   createLocalTracks(options: {
     devices: ('audio' | 'video' | 'desktop')[];
     firePermissionPromptIsShownEvent?: boolean;
+    micDeviceId?: string;
+    cameraDeviceId?: string;
+    constraints?: Record<string, unknown>;
   }): Promise<JitsiTrack[]>;
 }
 

--- a/src-vue/utils/applyAudioOutput.test.ts
+++ b/src-vue/utils/applyAudioOutput.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+import { applyAudioOutput, mediaElementsWithSink } from './applyAudioOutput';
+
+describe('applyAudioOutput', () => {
+  it('applies setSinkId to audio and video elements', async () => {
+    const ok = document.createElement('audio') as HTMLAudioElement & {
+      setSinkId: (id: string) => Promise<void>;
+    };
+    ok.setSinkId = vi.fn().mockResolvedValue(undefined);
+    const fail = document.createElement('video') as HTMLVideoElement & {
+      setSinkId: (id: string) => Promise<void>;
+    };
+    fail.setSinkId = vi.fn().mockRejectedValue(new Error('bad'));
+    const nosink = document.createElement('audio');
+    const root = document.createElement('div');
+    root.append(ok, fail, nosink);
+    expect(mediaElementsWithSink(root)).toHaveLength(2);
+    expect(await applyAudioOutput('spk-1', [ok, fail])).toBe(1);
+    expect(ok.setSinkId).toHaveBeenCalledWith('spk-1');
+    expect(await applyAudioOutput('')).toBe(0);
+  });
+
+  it('uses document media elements by default', async () => {
+    const el = document.createElement('audio') as HTMLAudioElement & {
+      setSinkId: (id: string) => Promise<void>;
+    };
+    el.setSinkId = vi.fn().mockResolvedValue(undefined);
+    document.body.append(el);
+    expect(await applyAudioOutput('spk-2')).toBe(1);
+    expect(el.setSinkId).toHaveBeenCalledWith('spk-2');
+    el.remove();
+  });
+});

--- a/src-vue/utils/applyAudioOutput.ts
+++ b/src-vue/utils/applyAudioOutput.ts
@@ -1,0 +1,26 @@
+type Sinkable = HTMLMediaElement & { setSinkId?: (id: string) => Promise<void> };
+
+export function mediaElementsWithSink(
+  root: ParentNode = document,
+): Sinkable[] {
+  return [...root.querySelectorAll<Sinkable>('audio, video')].filter(
+    (el) => typeof el.setSinkId === 'function',
+  );
+}
+
+export async function applyAudioOutput(
+  deviceId: string,
+  elements: Sinkable[] = mediaElementsWithSink(),
+): Promise<number> {
+  if (!deviceId) return 0;
+  let applied = 0;
+  for (const el of elements) {
+    try {
+      await el.setSinkId!(deviceId);
+      applied += 1;
+    } catch {
+      /* unsupported / invalid device */
+    }
+  }
+  return applied;
+}

--- a/src-vue/utils/attachGridTrack.test.ts
+++ b/src-vue/utils/attachGridTrack.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+import { makeTrack } from '@/test/makeTrack';
+import { attachGridTrack, detachGridTrack } from './attachGridTrack';
+
+describe('attachGridTrack', () => {
+  it('no-ops without an element', () => {
+    const track = makeTrack('video');
+    attachGridTrack(null, track);
+    expect(track.attach).not.toHaveBeenCalled();
+  });
+
+  it('clears when no track is provided', () => {
+    const el = document.createElement('video');
+    attachGridTrack(el, undefined);
+  });
+
+  it('attaches a live track', () => {
+    const el = document.createElement('video');
+    const track = makeTrack('video');
+    attachGridTrack(el, track);
+    expect(track.attach).toHaveBeenCalledWith(el);
+  });
+});
+
+describe('detachGridTrack', () => {
+  it('detaches and ignores failures', () => {
+    const el = document.createElement('video');
+    const track = makeTrack('video');
+    (track.detach as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error('gone');
+    });
+    detachGridTrack(el, track);
+    detachGridTrack(null, track);
+    detachGridTrack(el, undefined);
+  });
+});

--- a/src-vue/utils/attachGridTrack.ts
+++ b/src-vue/utils/attachGridTrack.ts
@@ -1,0 +1,27 @@
+import type { JitsiTrack } from '@/types/jitsi';
+import { clearMediaElement } from '@/utils/clearMediaElement';
+
+/** Attach a camera track to a grid tile, or clear the element when none is set. */
+export function attachGridTrack(
+  el: HTMLVideoElement | null,
+  track: JitsiTrack | undefined,
+): void {
+  if (!el) return;
+  clearMediaElement(el);
+  if (!track) return;
+  track.attach?.(el);
+}
+
+export function detachGridTrack(
+  el: HTMLVideoElement | null,
+  track: JitsiTrack | undefined,
+): void {
+  if (track && el) {
+    try {
+      track.detach?.(el);
+    } catch {
+      /* already detached */
+    }
+  }
+  clearMediaElement(el);
+}

--- a/src-vue/utils/createPreferredLocalTracks.test.ts
+++ b/src-vue/utils/createPreferredLocalTracks.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MEDIA_DEVICE_PREFS_KEY, saveMediaDevicePrefs } from './mediaDevicePrefs';
+import { createPreferredLocalTracks } from './createPreferredLocalTracks';
+
+describe('createPreferredLocalTracks', () => {
+  afterEach(() => {
+    localStorage.removeItem(MEDIA_DEVICE_PREFS_KEY);
+  });
+
+  it('omits device opts when no prefs are stored', async () => {
+    const engine = { createLocalTracks: vi.fn().mockResolvedValue([]) };
+    await createPreferredLocalTracks(engine, ['audio']);
+    expect(engine.createLocalTracks).toHaveBeenCalledWith(['audio']);
+  });
+
+  it('passes stored device ids for matching kinds', async () => {
+    saveMediaDevicePrefs({ audioinput: 'mic-1', videoinput: 'cam-1' });
+    const engine = { createLocalTracks: vi.fn().mockResolvedValue([]) };
+    await createPreferredLocalTracks(engine, ['audio', 'video']);
+    expect(engine.createLocalTracks).toHaveBeenCalledWith(['audio', 'video'], {
+      audioDeviceId: 'mic-1',
+      videoDeviceId: 'cam-1',
+    });
+  });
+});

--- a/src-vue/utils/createPreferredLocalTracks.ts
+++ b/src-vue/utils/createPreferredLocalTracks.ts
@@ -1,0 +1,13 @@
+import type { MediaService } from '@/services/MediaService';
+import type { JitsiTrack } from '@/types/jitsi';
+import { createTrackDeviceOpts } from '@/utils/mediaDevicePrefs';
+
+/** createLocalTracks with stored device ids, omitting opts when none are set. */
+export async function createPreferredLocalTracks(
+  engine: Pick<MediaService, 'createLocalTracks'>,
+  devices: Array<'audio' | 'video' | 'desktop'>,
+): Promise<JitsiTrack[]> {
+  const opts = createTrackDeviceOpts(devices);
+  if (!opts) return engine.createLocalTracks(devices);
+  return engine.createLocalTracks(devices, opts);
+}

--- a/src-vue/utils/deviceSettings.test.ts
+++ b/src-vue/utils/deviceSettings.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { deviceGroupLabel, fallbackDeviceLabel, supportsAudioOutput } from './deviceSettings';
+
+describe('deviceSettings', () => {
+  it('labels device groups and fallbacks', () => {
+    expect(deviceGroupLabel('audioinput')).toBe('Microphone');
+    expect(deviceGroupLabel('videoinput')).toBe('Camera');
+    expect(deviceGroupLabel('audiooutput')).toBe('Speaker');
+    expect(fallbackDeviceLabel('audioinput', 0)).toBe('Microphone 1');
+  });
+
+  it('detects setSinkId support', () => {
+    expect(supportsAudioOutput({ setSinkId: async () => undefined })).toBe(true);
+    expect(supportsAudioOutput({})).toBe(false);
+    expect(typeof supportsAudioOutput()).toBe('boolean');
+  });
+});

--- a/src-vue/utils/deviceSettings.ts
+++ b/src-vue/utils/deviceSettings.ts
@@ -1,0 +1,17 @@
+export type DeviceKind = 'audioinput' | 'videoinput' | 'audiooutput';
+
+export function deviceGroupLabel(kind: DeviceKind): string {
+  if (kind === 'audioinput') return 'Microphone';
+  if (kind === 'videoinput') return 'Camera';
+  return 'Speaker';
+}
+
+export function fallbackDeviceLabel(kind: DeviceKind, index: number): string {
+  return `${deviceGroupLabel(kind)} ${index + 1}`;
+}
+
+export function supportsAudioOutput(
+  proto: { setSinkId?: unknown } = HTMLMediaElement.prototype,
+): boolean {
+  return typeof proto.setSinkId === 'function';
+}

--- a/src-vue/utils/listMediaDevices.test.ts
+++ b/src-vue/utils/listMediaDevices.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { deviceLabel, listMediaDevices } from './listMediaDevices';
+
+function fakeDevice(kind: MediaDeviceKind, deviceId: string, label = ''): MediaDeviceInfo {
+  return { kind, deviceId, label, groupId: '', toJSON: () => ({}) } as MediaDeviceInfo;
+}
+
+describe('listMediaDevices', () => {
+  it('groups devices by kind', async () => {
+    const listed = await listMediaDevices(async () => [
+      fakeDevice('audioinput', 'm1', 'Mic'),
+      fakeDevice('videoinput', 'c1', 'Cam'),
+      fakeDevice('audiooutput', 's1', 'Speakers'),
+    ]);
+    expect(listed.audioInputs).toHaveLength(1);
+    expect(listed.videoInputs).toHaveLength(1);
+    expect(listed.audioOutputs).toHaveLength(1);
+  });
+
+  it('returns empty lists when enumerate fails', async () => {
+    const listed = await listMediaDevices(async () => {
+      throw new Error('denied');
+    });
+    expect(listed).toEqual({ audioInputs: [], videoInputs: [], audioOutputs: [] });
+  });
+
+  it('falls back when a device has no label', () => {
+    expect(deviceLabel(fakeDevice('audioinput', 'x'), 'Microphone 1')).toBe('Microphone 1');
+    expect(deviceLabel(fakeDevice('audioinput', 'x', '  Built-in  '), 'Microphone 1')).toBe(
+      'Built-in',
+    );
+  });
+
+  it('uses navigator.mediaDevices by default', async () => {
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: {
+        enumerateDevices: async () => [fakeDevice('audioinput', 'm1', 'Mic')],
+      },
+    });
+    const listed = await listMediaDevices();
+    expect(listed.audioInputs).toHaveLength(1);
+  });
+});

--- a/src-vue/utils/listMediaDevices.ts
+++ b/src-vue/utils/listMediaDevices.ts
@@ -1,0 +1,25 @@
+export type ListedMediaDevices = {
+  audioInputs: MediaDeviceInfo[];
+  videoInputs: MediaDeviceInfo[];
+  audioOutputs: MediaDeviceInfo[];
+};
+
+export async function listMediaDevices(
+  enumerate: () => Promise<MediaDeviceInfo[]> = () => navigator.mediaDevices.enumerateDevices(),
+): Promise<ListedMediaDevices> {
+  let devices: MediaDeviceInfo[] = [];
+  try {
+    devices = await enumerate();
+  } catch {
+    devices = [];
+  }
+  return {
+    audioInputs: devices.filter((d) => d.kind === 'audioinput'),
+    videoInputs: devices.filter((d) => d.kind === 'videoinput'),
+    audioOutputs: devices.filter((d) => d.kind === 'audiooutput'),
+  };
+}
+
+export function deviceLabel(device: MediaDeviceInfo, fallback: string): string {
+  return device.label?.trim() || fallback;
+}

--- a/src-vue/utils/mediaDevicePrefs.test.ts
+++ b/src-vue/utils/mediaDevicePrefs.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  MEDIA_DEVICE_PREFS_KEY,
+  createTrackDeviceOpts,
+  loadMediaDevicePrefs,
+  saveMediaDevicePrefs,
+} from './mediaDevicePrefs';
+
+describe('mediaDevicePrefs', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    localStorage.removeItem(MEDIA_DEVICE_PREFS_KEY);
+  });
+
+  it('returns empty prefs when nothing is stored', () => {
+    expect(loadMediaDevicePrefs()).toEqual({});
+  });
+
+  it('saves and reloads device ids', () => {
+    expect(saveMediaDevicePrefs({ audioinput: 'mic-1', videoinput: 'cam-1' })).toEqual({
+      audioinput: 'mic-1',
+      videoinput: 'cam-1',
+    });
+    expect(loadMediaDevicePrefs()).toEqual({
+      audioinput: 'mic-1',
+      videoinput: 'cam-1',
+    });
+  });
+
+  it('drops empty ids and ignores invalid JSON', () => {
+    saveMediaDevicePrefs({ audioinput: 'mic-1', videoinput: 'cam-1' });
+    saveMediaDevicePrefs({ audioinput: '', videoinput: 'cam-2' });
+    expect(loadMediaDevicePrefs().audioinput).toBeUndefined();
+    expect(loadMediaDevicePrefs().videoinput).toBe('cam-2');
+    localStorage.setItem(MEDIA_DEVICE_PREFS_KEY, '{not json');
+    expect(loadMediaDevicePrefs()).toEqual({});
+    localStorage.setItem(MEDIA_DEVICE_PREFS_KEY, 'null');
+    expect(loadMediaDevicePrefs()).toEqual({});
+    localStorage.setItem(MEDIA_DEVICE_PREFS_KEY, JSON.stringify({ audioinput: 1, videoinput: 'ok' }));
+    expect(loadMediaDevicePrefs()).toEqual({ videoinput: 'ok' });
+  });
+
+  it('survives localStorage failures', () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => {
+        throw new Error('blocked');
+      },
+      setItem: () => {
+        throw new Error('quota');
+      },
+    });
+    expect(loadMediaDevicePrefs()).toEqual({});
+    expect(saveMediaDevicePrefs({ audiooutput: 'spk' })).toEqual({ audiooutput: 'spk' });
+  });
+
+  it('builds createLocalTracks opts only when prefs match requested devices', () => {
+    expect(createTrackDeviceOpts(['audio'], {})).toBeUndefined();
+    expect(createTrackDeviceOpts(['audio'], { audioinput: 'm' })).toEqual({ audioDeviceId: 'm' });
+    expect(createTrackDeviceOpts(['video'], { audioinput: 'm', videoinput: 'c' })).toEqual({
+      videoDeviceId: 'c',
+    });
+    expect(createTrackDeviceOpts(['desktop'], { audioinput: 'm', videoinput: 'c' })).toBeUndefined();
+  });
+});

--- a/src-vue/utils/mediaDevicePrefs.ts
+++ b/src-vue/utils/mediaDevicePrefs.ts
@@ -1,0 +1,55 @@
+export type MediaDevicePrefs = {
+  audioinput?: string;
+  videoinput?: string;
+  audiooutput?: string;
+};
+
+export const MEDIA_DEVICE_PREFS_KEY = 'loungemesh.mediaDevices';
+
+function readStore(): unknown {
+  try {
+    const raw = localStorage.getItem(MEDIA_DEVICE_PREFS_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch {
+    return {};
+  }
+}
+
+export function loadMediaDevicePrefs(): MediaDevicePrefs {
+  const parsed = readStore();
+  if (!parsed || typeof parsed !== 'object') return {};
+  const rec = parsed as Record<string, unknown>;
+  const prefs: MediaDevicePrefs = {};
+  if (typeof rec.audioinput === 'string' && rec.audioinput) prefs.audioinput = rec.audioinput;
+  if (typeof rec.videoinput === 'string' && rec.videoinput) prefs.videoinput = rec.videoinput;
+  if (typeof rec.audiooutput === 'string' && rec.audiooutput) prefs.audiooutput = rec.audiooutput;
+  return prefs;
+}
+
+export function saveMediaDevicePrefs(patch: MediaDevicePrefs): MediaDevicePrefs {
+  const next = { ...loadMediaDevicePrefs(), ...patch };
+  for (const key of ['audioinput', 'videoinput', 'audiooutput'] as const) {
+    if (!next[key]) delete next[key];
+  }
+  try {
+    localStorage.setItem(MEDIA_DEVICE_PREFS_KEY, JSON.stringify(next));
+  } catch {
+    /* quota / private mode */
+  }
+  return next;
+}
+
+export type CreateTrackDeviceOpts = {
+  audioDeviceId?: string;
+  videoDeviceId?: string;
+};
+
+export function createTrackDeviceOpts(
+  devices: Array<'audio' | 'video' | 'desktop'>,
+  prefs: MediaDevicePrefs = loadMediaDevicePrefs(),
+): CreateTrackDeviceOpts | undefined {
+  const opts: CreateTrackDeviceOpts = {};
+  if (devices.includes('audio') && prefs.audioinput) opts.audioDeviceId = prefs.audioinput;
+  if (devices.includes('video') && prefs.videoinput) opts.videoDeviceId = prefs.videoinput;
+  return opts.audioDeviceId || opts.videoDeviceId ? opts : undefined;
+}

--- a/src-vue/utils/participantPlaybackGain.test.ts
+++ b/src-vue/utils/participantPlaybackGain.test.ts
@@ -19,4 +19,9 @@ describe('playbackGainForUser', () => {
   it('returns full volume for presenter regardless of proximity', () => {
     expect(playbackGainForUser({ mute: false }, 0.2, true)).toBe(1.0);
   });
+
+  it('returns full volume for megaphone regardless of proximity', () => {
+    expect(playbackGainForUser({ mute: false, properties: { megaphone: true } }, 0.1)).toBe(1.0);
+    expect(playbackGainForUser({ mute: true, properties: { megaphone: true } }, 0.1)).toBe(0);
+  });
 });

--- a/src-vue/utils/participantPlaybackGain.ts
+++ b/src-vue/utils/participantPlaybackGain.ts
@@ -1,10 +1,13 @@
+import { parseMegaphone } from '@/utils/sessionMegaphone';
+
 /** Effective Web Audio gain — muted participants are always silent. */
 export function playbackGainForUser(
-  user: { mute: boolean },
+  user: { mute?: boolean; properties?: Record<string, unknown> },
   proximityVolume: number,
   isPresenter?: boolean,
 ): number {
   if (user.mute) return 0;
   if (isPresenter) return 1.0;
+  if (parseMegaphone(user.properties?.megaphone)) return 1.0;
   return Math.max(0, Math.min(1, proximityVolume));
 }

--- a/src-vue/utils/sessionCommands.test.ts
+++ b/src-vue/utils/sessionCommands.test.ts
@@ -37,6 +37,10 @@ describe('handleSessionCommand', () => {
     conference.addUser('u2');
     handleSessionCommand('hand', { value: JSON.stringify({ id: 'u2', raised: true }) });
     expect(conference.users.u2.properties.handRaised).toBe(true);
+    handleSessionCommand('megaphone', { value: JSON.stringify({ id: 'u2', on: true }) });
+    expect(conference.users.u2.properties.megaphone).toBe(true);
+    handleSessionCommand('megaphone', { value: JSON.stringify({ id: 'u2' }) });
+    handleSessionCommand('megaphone', { value: 'not-json' });
   });
 
   it('plays hand raise sound only once per raise', async () => {

--- a/src-vue/utils/sessionCommands.ts
+++ b/src-vue/utils/sessionCommands.ts
@@ -6,6 +6,7 @@ import { useLocalStore } from '@/stores/localStore';
 import { getMediaEngineInstance } from '@/services/mediaEngineSingleton';
 import type { WhiteboardCommand } from '@/utils/whiteboardSync';
 import { applyParticipantHandRaised, parseHandRaised } from '@/utils/sessionHandRaise';
+import { applyParticipantMegaphone } from '@/utils/sessionMegaphone';
 import { pollActivityChanged } from '@/utils/sessionPoll';
 import { playUiSound } from '@/utils/uiSounds';
 import {
@@ -116,6 +117,12 @@ export function handleSessionCommand(name: string, payload: CommandPayload, send
       const data = parse<{ id?: string; raised?: boolean }>(payload);
       if (!data?.id || typeof data.raised !== 'boolean') break;
       applyParticipantHandRaised(data.id, data.raised, { notify: true });
+      break;
+    }
+    case 'megaphone': {
+      const data = parse<{ id?: string; on?: boolean }>(payload);
+      if (!data?.id || typeof data.on !== 'boolean') break;
+      applyParticipantMegaphone(data.id, data.on);
       break;
     }
     case 'poll': {

--- a/src-vue/utils/sessionMegaphone.test.ts
+++ b/src-vue/utils/sessionMegaphone.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+import { useConferenceStore } from '@/stores/conferenceStore';
+import { useLocalStore } from '@/stores/localStore';
+import { useSessionFeaturesStore } from '@/stores/sessionFeaturesStore';
+import { getMediaEngineInstance } from '@/services/mediaEngineSingleton';
+import { applyParticipantMegaphone, parseMegaphone } from './sessionMegaphone';
+
+describe('sessionMegaphone', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('parses megaphone values', () => {
+    expect(parseMegaphone(true)).toBe(true);
+    expect(parseMegaphone('true')).toBe(true);
+    expect(parseMegaphone(false)).toBe(false);
+    expect(parseMegaphone('false')).toBe(false);
+  });
+
+  it('updates local and remote megaphone properties', () => {
+    const conference = useConferenceStore();
+    const local = useLocalStore();
+    const features = useSessionFeaturesStore();
+    local.setMyID('local-1');
+    vi.spyOn(getMediaEngineInstance(), 'getLocalUserId').mockReturnValue('local-1');
+
+    applyParticipantMegaphone('remote-1', true);
+    expect(conference.users['remote-1']).toBeUndefined();
+
+    conference.addUser('remote-1');
+    applyParticipantMegaphone('remote-1', true);
+    expect(conference.users['remote-1'].properties.megaphone).toBe(true);
+
+    applyParticipantMegaphone('local-1', true);
+    expect(features.megaphone).toBe(true);
+
+    applyParticipantMegaphone('local-1', false);
+    expect(features.megaphone).toBe(false);
+  });
+
+  it('syncs local megaphone from engine id when store id is unset', () => {
+    const features = useSessionFeaturesStore();
+    const local = useLocalStore();
+    local.setMyID('');
+    vi.spyOn(getMediaEngineInstance(), 'getLocalUserId').mockReturnValue('engine-only');
+    applyParticipantMegaphone('engine-only', true);
+    expect(features.megaphone).toBe(true);
+  });
+});

--- a/src-vue/utils/sessionMegaphone.ts
+++ b/src-vue/utils/sessionMegaphone.ts
@@ -1,0 +1,27 @@
+import { useConferenceStore } from '@/stores/conferenceStore';
+import { useLocalStore } from '@/stores/localStore';
+import { useSessionFeaturesStore } from '@/stores/sessionFeaturesStore';
+import { getMediaEngineInstance } from '@/services/mediaEngineSingleton';
+
+export function parseMegaphone(value: unknown): boolean {
+  return value === true || value === 'true';
+}
+
+function isLocalParticipant(id: string): boolean {
+  const local = useLocalStore();
+  const engineId = getMediaEngineInstance().getLocalUserId();
+  return id === local.id || (!!engineId && id === engineId);
+}
+
+/** Sync megaphone state onto the local store and remote participant tiles. */
+export function applyParticipantMegaphone(participantId: string, on: boolean): void {
+  if (isLocalParticipant(participantId)) {
+    useSessionFeaturesStore().megaphone = on;
+  }
+  const user = useConferenceStore().users[participantId];
+  if (user) {
+    useConferenceStore().patchUser(participantId, {
+      properties: { ...user.properties, megaphone: on },
+    });
+  }
+}

--- a/src-vue/utils/sphereGrid.test.ts
+++ b/src-vue/utils/sphereGrid.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { isInHearingSphere, sphereGridMembers } from './sphereGrid';
+
+describe('sphereGrid', () => {
+  const origin = { x: 0, y: 0 };
+
+  it('includes nearby people and excludes those outside the audio radius', () => {
+    expect(isInHearingSphere(origin, { id: 'near', pos: { x: 10, y: 10 } })).toBe(true);
+    expect(isInHearingSphere(origin, { id: 'far', pos: { x: 2000, y: 2000 } })).toBe(false);
+  });
+
+  it('includes megaphone and stage occupants even when far', () => {
+    expect(
+      isInHearingSphere(origin, {
+        id: 'loud',
+        pos: { x: 2000, y: 2000 },
+        properties: { megaphone: true },
+      }),
+    ).toBe(true);
+    expect(
+      isInHearingSphere(origin, { id: 'stage', pos: { x: 2000, y: 2000 } }, { presenterId: 'stage' }),
+    ).toBe(true);
+  });
+
+  it('always lists the local user first plus in-sphere remotes', () => {
+    const members = sphereGridMembers(
+      origin,
+      'me',
+      'Ada',
+      [
+        { id: 'near', pos: { x: 5, y: 5 }, displayName: 'Near' },
+        { id: 'far', pos: { x: 3000, y: 3000 }, displayName: 'Far' },
+        { id: 'anon', pos: { x: 8, y: 8 } },
+      ],
+    );
+    expect(members[0]).toEqual({ id: 'me', displayName: 'Ada', isLocal: true });
+    expect(members.map((m) => m.id)).toEqual(['me', 'near', 'anon']);
+    expect(members.find((m) => m.id === 'anon')?.displayName).toBe('Participant');
+  });
+
+  it('falls back to local id and You when identity is empty', () => {
+    const members = sphereGridMembers(origin, '', '', []);
+    expect(members).toEqual([{ id: 'local', displayName: 'You', isLocal: true }]);
+  });
+});

--- a/src-vue/utils/sphereGrid.ts
+++ b/src-vue/utils/sphereGrid.ts
@@ -1,0 +1,48 @@
+import { getVolumeByDistance, type Vector2 } from '@/utils/vector';
+import { parseMegaphone } from '@/utils/sessionMegaphone';
+
+export type SphereGridCandidate = {
+  id: string;
+  pos: Vector2;
+  properties?: Record<string, unknown>;
+  displayName?: string;
+};
+
+export function isInHearingSphere(
+  myPos: Vector2,
+  candidate: SphereGridCandidate,
+  opts?: { presenterId?: string },
+): boolean {
+  if (opts?.presenterId && candidate.id === opts.presenterId) return true;
+  if (parseMegaphone(candidate.properties?.megaphone)) return true;
+  return getVolumeByDistance(myPos, candidate.pos) > 0;
+}
+
+export type SphereGridMember = {
+  id: string;
+  displayName: string;
+  isLocal: boolean;
+};
+
+/** Local user plus remotes currently in hearing range (or megaphone / stage). */
+export function sphereGridMembers(
+  myPos: Vector2,
+  localId: string,
+  localName: string,
+  remotes: SphereGridCandidate[],
+  opts?: { presenterId?: string },
+): SphereGridMember[] {
+  const local: SphereGridMember = {
+    id: localId || 'local',
+    displayName: localName || 'You',
+    isLocal: true,
+  };
+  const others = remotes
+    .filter((candidate) => isInHearingSphere(myPos, candidate, opts))
+    .map((candidate) => ({
+      id: candidate.id,
+      displayName: candidate.displayName || 'Participant',
+      isLocal: false,
+    }));
+  return [local, ...others];
+}


### PR DESCRIPTION
## Summary
- Add a **Grid view** toggle next to zoom that overlays tiles for people in your hearing sphere (proximity volume above zero, plus megaphone/stage).
- Local-only: it does not change anyone else’s view or join a second conference.
- Mobile: 1–2 columns, no horizontal overflow. Docs: [In-room controls](https://docs.loungemesh.com/guide/in-room-controls) (after docs deploy).

This is **phase 3 of 3**. It includes #95 (devices) and the megaphone PR. Merge those first.

## Test plan
- [ ] `npm run typecheck` / `npm test` / `npm run build` / `npm run docs:build`
- [ ] People in hearing range appear as tiles; people outside the sphere do not
- [ ] Toggle off returns to the map; pan/zoom still work
- [ ] Grid is local-only (the other person is not forced into grid)
- [ ] 768px / 480px: 44px close target, no horizontal page scroll


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Add local sphere-grid viewing, room-wide megaphone audio, and in-session media-device controls.

New Features:
- Add a local sphere grid showing the current user and nearby participants, including stage presenters and megaphone speakers.
- Add in-session device selection for cameras, microphones, and supported speakers with persisted browser preferences.
- Add a megaphone control that broadcasts a participant’s voice across the room and highlights their tile.

Bug Fixes:
- Honor selected media devices when creating or replacing local tracks and apply supported audio output devices.

Enhancements:
- Improve zoom controls for fixed positioning and mobile touch targets.
- Extend participant state synchronization and playback behavior for megaphone speakers.

Documentation:
- Add user-facing documentation for device controls, megaphone behavior, and sphere grid view.
- Update implementation status to mark device selection, megaphone, and sphere grid features complete.

Tests:
- Add coverage for sphere-grid membership and rendering, device settings, media-device preferences, megaphone behavior, and related session synchronization.

Chores:
- Add megaphone and grid icons to the shared icon registry.